### PR TITLE
Rename package to zproto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "zaber-protocol"
+name = "zproto"
 version = "0.1.0"
 authors = ["Stephen Hunt <stphnhnt.git@gmail.com>"]
 edition = "2021"

--- a/examples/example-ascii.rs
+++ b/examples/example-ascii.rs
@@ -1,5 +1,5 @@
 use simple_logger::SimpleLogger;
-use zaber_protocol::ascii::{check, IntoCommand as _, Port, Warning};
+use zproto::ascii::{check, IntoCommand as _, Port, Warning};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Enable logging

--- a/examples/example-binary.rs
+++ b/examples/example-binary.rs
@@ -1,6 +1,6 @@
 use simple_logger::SimpleLogger;
-use zaber_protocol::ascii::{check::unchecked, IntoCommand as _, Port as AsciiPort};
-use zaber_protocol::binary::{command::*, Port};
+use zproto::ascii::{check::unchecked, IntoCommand as _, Port as AsciiPort};
+use zproto::binary::{command::*, Port};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Enable logging

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -3,7 +3,7 @@
 //! All communication with Zaber products starts with a [`Port`], which can be either a serial or TCP port:
 //!
 //! ```rust
-//! # use zaber_protocol::{error::Error, ascii::Port};
+//! # use zproto::{error::Error, ascii::Port};
 //! # fn wrapper() -> Result<(), Error> {
 //! let mut port = Port::open_serial("/dev/ttyUSB0")?;
 //! // OR
@@ -19,7 +19,7 @@
 //! * using the [`Command`]'s builder methods
 //!
 //! ```rust
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     ascii::{Command, Port},
 //! #     backend::Backend,
 //! #     error::Error
@@ -35,9 +35,9 @@
 //! methods it `&str` and a few other types to easily convert them into a [`Command`]:
 //!
 //! ```rust
-//! # use zaber_protocol::{ascii::Port, backend::Backend, error::Error};
+//! # use zproto::{ascii::Port, backend::Backend, error::Error};
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::ascii::IntoCommand as _;
+//! use zproto::ascii::IntoCommand as _;
 //!
 //! let reply = port.command_reply("get device.id".to(1))?; // Sends `/1 get device.id`
 //! let device_id: u32 = reply.data().parse()?;
@@ -57,10 +57,10 @@
 //! be checked:
 //!
 //! ```rust
-//! # use zaber_protocol::{ascii::Port, backend::Backend, error::Error};
-//! # use zaber_protocol::ascii::IntoCommand as _;
+//! # use zproto::{ascii::Port, backend::Backend, error::Error};
+//! # use zproto::ascii::IntoCommand as _;
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::ascii::check::{flag_ok_and, warning_is};
+//! use zproto::ascii::check::{flag_ok_and, warning_is};
 //!
 //! let reply = port.command_reply_with_check(
 //!    "get device.id".to(1),
@@ -78,7 +78,7 @@
 //! read an [`Alert`] use the [`response`](Port::response) method:
 //!
 //! ```rust
-//! # use zaber_protocol::{ascii::{Alert, Port}, backend::Backend};
+//! # use zproto::{ascii::{Alert, Port}, backend::Backend};
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
 //! let alert: Alert = port.response()?;
 //! # Ok(())
@@ -89,10 +89,10 @@
 //! [`command_reply_infos`](Port::command_reply_infos) method:
 //!
 //! ```rust
-//! # use zaber_protocol::{ascii::Port, backend::Backend};
-//! # use zaber_protocol::ascii::IntoCommand as _;
+//! # use zproto::{ascii::Port, backend::Backend};
+//! # use zproto::ascii::IntoCommand as _;
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::ascii::check::{flag_ok_and, warning_is};
+//! use zproto::ascii::check::{flag_ok_and, warning_is};
 //!
 //! let (reply, infos) = port.command_reply_infos("stream buffer 1 print".to(1))?;
 //! println!("{}", reply);  // `@01 0 OK IDLE -- 0` (for example)
@@ -106,7 +106,7 @@
 //! It also provides convenience functions for common tasks:
 //!
 //! ```rust
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     ascii::{Port, IntoCommand as _},
 //! #     backend::Backend
 //! # };
@@ -136,14 +136,14 @@ pub use response::*;
 /// desired target.
 ///
 /// ```rust
-/// # use zaber_protocol::ascii::Target;
+/// # use zproto::ascii::Target;
 /// let target = Target::device(1).axis(2);
 /// ```
 ///
 /// Or you can create a target from a `u8` or `tuple` of `u8`s:
 ///
 /// ```rust
-/// # use zaber_protocol::ascii::Target;
+/// # use zproto::ascii::Target;
 /// assert_eq!(Target::device(1), Target::from(1));
 /// assert_eq!(Target::device(1).axis(2), Target::from((1, 2)));
 /// ```

--- a/src/ascii/command.rs
+++ b/src/ascii/command.rs
@@ -254,8 +254,8 @@ impl Default for Command {
 /// A trait to convert a type into the body of an ASCII [`Command`].
 ///
 /// ```rust
-/// # use zaber_protocol::ascii::Command;
-/// use zaber_protocol::ascii::IntoCommand as _;
+/// # use zproto::ascii::Command;
+/// use zproto::ascii::IntoCommand as _;
 ///
 /// let command: Command = "get maxspeed".to(1);
 /// ```

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 /// ## Example
 ///
 /// ```rust
-/// # use zaber_protocol::ascii::OpenSerialOptions;
+/// # use zproto::ascii::OpenSerialOptions;
 /// # use std::time::Duration;
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenSerialOptions::new()
@@ -145,7 +145,7 @@ impl Default for OpenSerialOptions {
 /// ## Example
 ///
 /// ```rust
-/// # use zaber_protocol::ascii::OpenTcpOptions;
+/// # use zproto::ascii::OpenTcpOptions;
 /// # use std::time::Duration;
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenTcpOptions::new()
@@ -275,7 +275,7 @@ impl Port<Serial> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::ascii::Port;
+    /// # use zproto::ascii::Port;
     /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut port = Port::open_serial("/dev/ttyUSB0")?;
     /// # Ok(())
@@ -294,7 +294,7 @@ impl Port<TcpStream> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::ascii::Port;
+    /// # use zproto::ascii::Port;
     /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut port = Port::open_tcp("198.168.0.1:7770")?;
     /// # Ok(())
@@ -344,7 +344,7 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::{Command, Port}, backend::Backend};
+    /// # use zproto::{ascii::{Command, Port}, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     /// port.command(Command::empty())?;
     /// # Ok(())
@@ -377,9 +377,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// let reply = port.command_reply("get maxspeed".to(1))?;
     /// # Ok(())
@@ -394,9 +394,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::{check::flag_ok, IntoCommand as _};
+    /// use zproto::ascii::{check::flag_ok, IntoCommand as _};
     ///
     /// let reply = port.command_reply_with_check("home".to(1), flag_ok())?;  // Home, but ignore any warning flags that might be present
     /// # Ok(())
@@ -435,9 +435,9 @@ impl<B: Backend> Port<B> {
     ///
     /// ## Example
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend, error::AsciiError};
+    /// # use zproto::{ascii::Port, backend::Backend, error::AsciiError};
     /// # fn wrapper<B: Backend>(port: &mut Port<B>) -> Result<(), AsciiError> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// let (reply, info_messages) = port.command_reply_infos("stream buffer 1 print".to(1))?;
     /// # Ok(())
@@ -454,13 +454,13 @@ impl<B: Backend> Port<B> {
     ///
     /// ## Example
     /// ```rust
-    /// # use zaber_protocol::{
+    /// # use zproto::{
     /// #     ascii::{Port, AnyResponse},
     /// #     backend::Backend,
     /// #     error::{AsciiCheckError, AsciiError}
     /// # };
     /// # fn wrapper<B: Backend>(port: &mut Port<B>) -> Result<(), AsciiError> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// let (reply, info_messages) = port.command_reply_infos_with_check(
     ///    "stream buffer 1 print".to(1),
@@ -515,9 +515,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// let replies = port.command_reply_n("get system.serial".to_all(), 5)?;
     /// # Ok(())
@@ -536,9 +536,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::{check::unchecked, IntoCommand as _};
+    /// use zproto::ascii::{check::unchecked, IntoCommand as _};
     ///
     /// let replies = port.command_reply_n_with_check("get system.serial".to_all(), 5, unchecked())?;
     /// # Ok(())
@@ -567,9 +567,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// let replies = port.command_replies_until_timeout("get system.serial".to_all())?;
     /// # Ok(())
@@ -587,9 +587,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::{check::flag_ok, IntoCommand as _};
+    /// use zproto::ascii::{check::flag_ok, IntoCommand as _};
     ///
     /// let replies = port.command_replies_until_timeout_with_check(
     ///     "get system.serial".to_all(),
@@ -806,7 +806,7 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::{Reply, Info, Port}, backend::Backend};
+    /// # use zproto::{ascii::{Reply, Info, Port}, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     /// let reply: Reply = port.response()?;
     /// let info: Info = port.response()?;
@@ -827,9 +827,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::{Alert, Port}, backend::Backend};
+    /// # use zproto::{ascii::{Alert, Port}, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::check::warning_below_fault;
+    /// use zproto::ascii::check::warning_below_fault;
     /// let reply: Alert = port.response_with_check(warning_below_fault())?;
     /// # Ok(())
     /// # }
@@ -852,7 +852,7 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::{Info, Port}, backend::Backend};
+    /// # use zproto::{ascii::{Info, Port}, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     /// let reply: Vec<Info> = port.response_n(3)?;
     /// # Ok(())
@@ -872,9 +872,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::{Reply, Port}, backend::Backend};
+    /// # use zproto::{ascii::{Reply, Port}, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::check::{flag_ok_and, warning_below_fault};
+    /// use zproto::ascii::check::{flag_ok_and, warning_below_fault};
     /// let reply: Vec<Reply> = port.response_n_with_check(3, flag_ok_and(warning_below_fault()))?;
     /// # Ok(())
     /// # }
@@ -901,8 +901,8 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::ascii::{AnyResponse, Port};
-    /// # use zaber_protocol::backend::Backend;
+    /// # use zproto::ascii::{AnyResponse, Port};
+    /// # use zproto::backend::Backend;
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     /// let reply: Vec<AnyResponse> = port.responses_until_timeout()?;
     /// # Ok(())
@@ -922,10 +922,10 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::ascii::{AnyResponse, Port};
-    /// # use zaber_protocol::backend::Backend;
+    /// # use zproto::ascii::{AnyResponse, Port};
+    /// # use zproto::backend::Backend;
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::check::unchecked;
+    /// use zproto::ascii::check::unchecked;
     /// let reply: Vec<AnyResponse> = port.responses_until_timeout_with_check(unchecked())?;
     /// # Ok(())
     /// # }
@@ -951,9 +951,9 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::ascii::IntoCommand as _;
+    /// use zproto::ascii::IntoCommand as _;
     ///
     /// port.poll_until("".to((1,1)), |reply| { reply.warning() != "FZ" })?;
     /// # Ok(())
@@ -981,7 +981,7 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::{ascii::Port, backend::Backend};
+    /// # use zproto::{ascii::Port, backend::Backend};
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     /// port.poll_until_idle((1,1))?;
     /// # Ok(())
@@ -1000,7 +1000,7 @@ impl<B: Backend> Port<B> {
     ///
     /// ## Example
     /// ```rust
-    /// # use zaber_protocol::{error::AsciiError, ascii::{Port, Reply, IntoCommand as _}, backend::Backend};
+    /// # use zproto::{error::AsciiError, ascii::{Port, Reply, IntoCommand as _}, backend::Backend};
     /// # use std::time::Duration;
     /// # fn helper<B: Backend>(mut port: Port<B>) -> Result<Reply, AsciiError> {
     /// {

--- a/src/ascii/response/check.rs
+++ b/src/ascii/response/check.rs
@@ -12,7 +12,7 @@
 //! `OK` and no warning flags you can use:
 //!
 //! ```rust
-//! # use zaber_protocol::ascii::{
+//! # use zproto::ascii::{
 //! #     Flag,
 //! #     Reply,
 //! #     check::{all, Check, flag_is, warning_is_none},
@@ -73,7 +73,7 @@ mod private {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, warning_is}, Warning, Reply};
+/// # use zproto::ascii::{check::{Check, warning_is}, Warning, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// warning_is("WR")
 /// # }
@@ -103,7 +103,7 @@ where
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, warning_in}, Warning, Reply};
+/// # use zproto::ascii::{check::{Check, warning_in}, Warning, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// warning_in(["WR", "WH"])
 /// # }
@@ -169,7 +169,7 @@ pub fn warning_is_none<R: ResponseWithWarning>() -> impl Check<R> {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, status_is}, Status, Reply};
+/// # use zproto::ascii::{check::{Check, status_is}, Status, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// status_is(Status::Idle)
 /// # }
@@ -188,7 +188,7 @@ pub fn status_is<R: ResponseWithStatus>(status: Status) -> impl Check<R> {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, flag_is}, Flag, Reply};
+/// # use zproto::ascii::{check::{Check, flag_is}, Flag, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// flag_is(Flag::Ok)
 /// # }
@@ -212,7 +212,7 @@ pub fn flag_ok() -> impl Check<Reply> {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, flag_ok_and, warning_is}, Flag, Reply};
+/// # use zproto::ascii::{check::{Check, flag_ok_and, warning_is}, Flag, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// flag_ok_and(warning_is("WR"))
 /// # }
@@ -228,7 +228,7 @@ pub fn flag_ok_and(check: impl Check<Reply>) -> impl Check<Reply> {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, parsed_data_is}, Reply};
+/// # use zproto::ascii::{check::{Check, parsed_data_is}, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// parsed_data_is(256)
 /// # }
@@ -258,7 +258,7 @@ pub fn parsed_data_is<
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{*, check::*};
+/// # use zproto::ascii::{*, check::*};
 /// # fn wrapper() -> impl Check<Reply> {
 /// all((flag_is(Flag::Ok), warning_in(("WR", "WH"))))
 /// # }
@@ -271,7 +271,7 @@ pub fn all<R: Response, C: CheckAll<R>>(checks: C) -> impl Check<R> {
 ///
 /// For [`Reply`](crate::ascii::Reply) this is equivalent to
 /// ```rust
-/// # use zaber_protocol::ascii::{check::*, *};
+/// # use zproto::ascii::{check::*, *};
 /// # fn wrapper() -> impl Check<Reply> {
 /// all((flag_is(Flag::Ok), warning_is(Warning::NONE)))
 /// # }
@@ -279,7 +279,7 @@ pub fn all<R: Response, C: CheckAll<R>>(checks: C) -> impl Check<R> {
 ///
 /// For [`Alert`](crate::ascii::Alert) this is equivalent to
 /// ```rust
-/// # use zaber_protocol::ascii::{check::*, *};
+/// # use zproto::ascii::{check::*, *};
 /// # fn wrapper() -> impl Check<Alert> {
 /// warning_is(Warning::NONE)
 /// # }
@@ -304,7 +304,7 @@ pub fn unchecked<R: Response>() -> impl Check<R> {
 ///
 /// ## Example
 /// ```rust
-/// # use zaber_protocol::ascii::{check::{Check, predicate}, Reply};
+/// # use zproto::ascii::{check::{Check, predicate}, Reply};
 /// # fn wrapper() -> impl Check<Reply> {
 /// let expected_value = "256";
 /// let check = predicate(move |reply: &Reply| {

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -7,7 +7,7 @@
 //! All communication with Zaber products starts with a [`Port`], which can be either a serial or TCP port:
 //!
 //! ```
-//! # use zaber_protocol::binary::Port;
+//! # use zproto::binary::Port;
 //! # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut port = Port::open_serial("/dev/ttyUSB0")?;
 //! // OR
@@ -26,13 +26,13 @@
 //!     also use a `u8`).
 //!
 //! ```
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     binary::Port,
 //! #     backend::Backend,
 //! # };
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
 //! // Send the Home command to all devices (address 0)
-//! use zaber_protocol::binary::command::HOME;
+//! use zproto::binary::command::HOME;
 //! let reply = port.tx_rx((0, HOME))?;
 //! # Ok(())
 //! # }
@@ -44,13 +44,13 @@
 //! and other types.
 //!
 //! ```
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     binary::Port,
 //! #     backend::Backend,
 //! # };
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
 //! // Move device 1 to the absolute position 10,000.
-//! use zaber_protocol::binary::command::*;
+//! use zproto::binary::command::*;
 //! let reply = port.tx_rx((1, MOVE_ABSOLUTE, 10000))?;
 //! // OR
 //! let reply = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
@@ -91,12 +91,12 @@
 //! for you at compile time.
 //!
 //! ```
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     binary::Port,
 //! #     backend::Backend,
 //! # };
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::binary::command::*;
+//! use zproto::binary::command::*;
 //! let reply = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
 //! let speed = reply.data()?; // `speed` is an `i32`
 //! let reply = port.tx_rx((0, RETURN_SETTING, SET_HOME_STATUS))?;
@@ -113,12 +113,12 @@
 //! or passing the wrong data type, will result in a compile time error.
 //!
 //! ```compile_fail
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     binary::Port,
 //! #     backend::Backend,
 //! # };
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::binary::command::*;
+//! use zproto::binary::command::*;
 //! let reply = port.tx_rx((0, MOVE_ABSOLUTE))?;  // ERROR: the data field is missing!
 //! let reply = port.tx_rx((0, MOVE_ABSOLUTE, true))?;  // ERROR: the data has the incorrect type!
 //! let reply = port.tx_rx((0, RESET));  // ERROR: Devices do not respond to the RESET command!
@@ -135,7 +135,7 @@
 //! ```compile_fail
 //! // This will not compile because SET_TARGET_SPEED and SET_ACCELERATION
 //! // are different types.
-//! use zaber_protocol::binary::command::*;
+//! use zproto::binary::command::*;
 //! let commands = [(0, SET_TARGET_SPEED, 10000), (0, SET_ACCELERATION, 5000)];
 //! ```
 //!
@@ -146,7 +146,7 @@
 //!
 //! ```
 //! // This works now.
-//! use zaber_protocol::binary::command::untyped::*;
+//! use zproto::binary::command::untyped::*;
 //! let commands = [(0, SET_TARGET_SPEED, 10000), (0, SET_ACCELERATION, 5000)];
 //! ```
 //!
@@ -154,12 +154,12 @@
 //! automatic type conversion -- you will have to pick the types yourself.
 //!
 //! ```
-//! # use zaber_protocol::{
+//! # use zproto::{
 //! #     binary::Port,
 //! #     backend::Backend,
 //! # };
 //! # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-//! use zaber_protocol::binary::command::untyped::*;
+//! use zproto::binary::command::untyped::*;
 //! let reply = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
 //! let speed: i32 = reply.data()?; // Notice that the type must be specified.
 //! // The compiler cannot tell if you have picked the wrong type so this will
@@ -262,12 +262,12 @@ impl<C: traits::Command> DeviceMessage<C> {
     /// ## Example
     ///
     /// ```
-    /// # use zaber_protocol::{
+    /// # use zproto::{
     /// #     binary::Port,
     /// #     backend::Backend,
     /// # };
     /// # fn wrapper<B: Backend>(mut port: Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::binary::command::*;
+    /// use zproto::binary::command::*;
     /// let reply = port.tx_rx((0, RETURN_SETTING, SET_HOME_STATUS))?;
     /// let homed = reply.data()?;  // `homed` is a `bool`
     /// let reply = port.tx_rx((0, RETURN_SETTING, untyped::SET_HOME_STATUS))?;
@@ -349,7 +349,7 @@ where
 /// For convenience it is comparable to [`f32`].
 ///
 /// ```
-/// # use zaber_protocol::binary::Version;
+/// # use zproto::binary::Version;
 /// let version = Version::new(7, 24).unwrap();
 /// assert_eq!(version, 7.24);
 /// ```

--- a/src/binary/port.rs
+++ b/src/binary/port.rs
@@ -23,7 +23,7 @@ use std::{
 /// ## Example
 ///
 /// ```rust
-/// # use zaber_protocol::binary::OpenSerialOptions;
+/// # use zproto::binary::OpenSerialOptions;
 /// # use std::time::Duration;
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenSerialOptions::new()
@@ -118,7 +118,7 @@ impl Default for OpenSerialOptions {
 /// ## Example
 ///
 /// ```rust
-/// # use zaber_protocol::binary::OpenTcpOptions;
+/// # use zproto::binary::OpenTcpOptions;
 /// # use std::time::Duration;
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenTcpOptions::new()
@@ -255,7 +255,7 @@ impl Port<Serial> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::binary::Port;
+    /// # use zproto::binary::Port;
     /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut port = Port::open_serial("/dev/ttyUSB0")?;
     /// # Ok(())
@@ -274,7 +274,7 @@ impl Port<TcpStream> {
     /// ## Example
     ///
     /// ```rust
-    /// # use zaber_protocol::binary::Port;
+    /// # use zproto::binary::Port;
     /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut port = Port::open_tcp("/dev/ttyUSB0")?;
     /// # Ok(())
@@ -325,12 +325,12 @@ impl<B: Backend> Port<B> {
     ///
     /// ## Example
     /// ```
-    /// # use zaber_protocol:: {
+    /// # use zproto:: {
     /// #   backend::Backend,
     /// #   binary::{DeviceMessage, Port},
     /// # };
     /// # fn wrapper<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::binary::command::*;
+    /// use zproto::binary::command::*;
     /// let reply = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
     /// let value = reply.data()?;
     /// # Ok(())
@@ -456,12 +456,12 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```
-    /// # use zaber_protocol:: {
+    /// # use zproto:: {
     /// #   backend::Backend,
     /// #   binary::{DeviceMessage, Port},
     /// # };
     /// # fn wrapper<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::binary::command::*;
+    /// use zproto::binary::command::*;
     /// let reply = port.rx(MANUAL_MOVE_TRACKING)?;
     /// # Ok(())
     /// # }
@@ -584,12 +584,12 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```
-    /// # use zaber_protocol:: {
+    /// # use zproto:: {
     /// #   backend::Backend,
     /// #   binary::{DeviceMessage, Port},
     /// # };
     /// # fn wrapper<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    /// use zaber_protocol::binary::command::*;
+    /// use zproto::binary::command::*;
     /// // Wait until device 1 has passed position 10000.
     /// let last_reply = port.poll_until(
     ///     (1, RETURN_CURRENT_POSITION),
@@ -641,7 +641,7 @@ impl<B: Backend> Port<B> {
     /// ## Example
     ///
     /// ```
-    /// # use zaber_protocol:: {
+    /// # use zproto:: {
     /// #   backend::Backend,
     /// #   binary::{DeviceMessage, Port},
     /// # };
@@ -671,10 +671,10 @@ impl<B: Backend> Port<B> {
     ///
     /// ## Example
     /// ```rust
-    /// # use zaber_protocol::{error::BinaryError, binary::Port, backend::Backend};
+    /// # use zproto::{error::BinaryError, binary::Port, backend::Backend};
     /// # use std::time::Duration;
     /// # fn helper<B: Backend>(mut port: Port<B>) -> Result<(), BinaryError> {
-    /// use zaber_protocol::binary::command::*;
+    /// use zproto::binary::command::*;
     /// {
     ///     let mut guard = port.timeout_guard(Some(Duration::from_secs(25)))?;
     ///     // All commands within this scope will use a 25 second timeout

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 //! higher level enums, allowing them to be used with `?`:
 //!
 //! ```
-//! use zaber_protocol::error::{AsciiUnexpectedError, Error};
+//! use zproto::error::{AsciiUnexpectedError, Error};
 //!
 //! fn foo() -> Result<(), AsciiUnexpectedError> {
 //!     // ...
@@ -25,7 +25,7 @@
 //! [`From`]/[`Into`] to retrieve the offending response.
 //!
 //! ```
-//! # use zaber_protocol::{ascii, error::AsciiUnexpectedError};
+//! # use zproto::{ascii, error::AsciiUnexpectedError};
 //! #
 //! # fn wrapper() {
 //! let error: AsciiUnexpectedError = //...

--- a/test/binary/01-type-inference.rs
+++ b/test/binary/01-type-inference.rs
@@ -1,4 +1,4 @@
-use zaber_protocol::binary::{DeviceMessage, Port, command::*};
+use zproto::binary::{DeviceMessage, Port, command::*};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut port = Port::open_serial("/dev/nonexistant")?;

--- a/test/binary/02-port-parameters.rs
+++ b/test/binary/02-port-parameters.rs
@@ -1,6 +1,6 @@
 //! Tests to confirm that port methods accept/reject commands appropriately at
 //! compile time.
-use zaber_protocol::{
+use zproto::{
     backend::Backend,
     binary::{command::*, Port}
 };

--- a/test/binary/02-port-parameters.stderr
+++ b/test/binary/02-port-parameters.stderr
@@ -12,11 +12,11 @@ error[E0277]: the trait bound `(u8, Reset): ElicitsResponse` is not satisfied
               <(u8, EchoData) as ElicitsResponse>
               <(u8, Home) as ElicitsResponse>
             and 74 others
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
 
 error[E0277]: the trait bound `Home: TakesData<i32>` is not satisfied
    --> test/binary/02-port-parameters.rs:10:24
@@ -27,11 +27,11 @@ error[E0277]: the trait bound `Home: TakesData<i32>` is not satisfied
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, Home, i32)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesNoData` is not satisfied
    --> test/binary/02-port-parameters.rs:11:24
@@ -42,11 +42,11 @@ error[E0277]: the trait bound `MoveAbsolute: TakesNoData` is not satisfied
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, MoveAbsolute)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesData<bool>` is not satisfied
    --> test/binary/02-port-parameters.rs:12:24
@@ -59,11 +59,11 @@ error[E0277]: the trait bound `MoveAbsolute: TakesData<bool>` is not satisfied
     = help: the following implementations were found:
               <MoveAbsolute as TakesData<i32>>
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, MoveAbsolute, bool)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
 
 error[E0277]: the trait bound `u8: TakesNoData` is not satisfied
    --> test/binary/02-port-parameters.rs:14:24
@@ -74,38 +74,38 @@ error[E0277]: the trait bound `u8: TakesNoData` is not satisfied
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, u8)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
 
-error[E0277]: the trait bound `zaber_protocol::binary::command::types::Error: TakesNoData` is not satisfied
+error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesNoData` is not satisfied
    --> test/binary/02-port-parameters.rs:16:13
     |
 16  |     port.tx((0, ERROR))?;  // Reply-only commands cannot be transmitted
-    |          -- ^^^^^^^^^^ the trait `TakesNoData` is not implemented for `zaber_protocol::binary::command::types::Error`
+    |          -- ^^^^^^^^^^ the trait `TakesNoData` is not implemented for `zproto::binary::command::types::Error`
     |          |
     |          required by a bound introduced by this call
     |
-    = note: required because of the requirements on the impl of `TxMessage` for `(u8, zaber_protocol::binary::command::types::Error)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx`
+    = note: required because of the requirements on the impl of `TxMessage` for `(u8, zproto::binary::command::types::Error)`
+note: required by a bound in `zproto::binary::Port::<B>::tx`
    --> src/binary/port.rs
     |
     |     pub fn tx<M: traits::TxMessage>(&mut self, message: M) -> Result<Option<u8>, BinaryError> {
-    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx`
+    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx`
 
-error[E0277]: the trait bound `zaber_protocol::binary::command::types::Error: TakesData<i32>` is not satisfied
+error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesData<i32>` is not satisfied
    --> test/binary/02-port-parameters.rs:17:13
     |
 17  |     port.tx((0, ERROR, 0i32))?;  // Reply-only commands cannot be transmitted
-    |          -- ^^^^^^^^^^^^^^^^ the trait `TakesData<i32>` is not implemented for `zaber_protocol::binary::command::types::Error`
+    |          -- ^^^^^^^^^^^^^^^^ the trait `TakesData<i32>` is not implemented for `zproto::binary::command::types::Error`
     |          |
     |          required by a bound introduced by this call
     |
-    = note: required because of the requirements on the impl of `TxMessage` for `(u8, zaber_protocol::binary::command::types::Error, i32)`
-note: required by a bound in `zaber_protocol::binary::Port::<B>::tx`
+    = note: required because of the requirements on the impl of `TxMessage` for `(u8, zproto::binary::command::types::Error, i32)`
+note: required by a bound in `zproto::binary::Port::<B>::tx`
    --> src/binary/port.rs
     |
     |     pub fn tx<M: traits::TxMessage>(&mut self, message: M) -> Result<Option<u8>, BinaryError> {
-    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `zaber_protocol::binary::Port::<B>::tx`
+    |                  ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx`

--- a/test/binary/03-reply-data.rs
+++ b/test/binary/03-reply-data.rs
@@ -1,4 +1,4 @@
-use zaber_protocol::{
+use zproto::{
     backend::Backend,
     binary::{command::*, Port}
 };


### PR DESCRIPTION
This shortens the name and allows Zaber to release a "zaber_*"
package in the future.