### PR TITLE
Allow the release workflow to publish to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo publish --all-features --locked --verbose --dry-run
+      - run: cargo publish --all-features --locked --verbose
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Remove the `--dry-run` argument so the crate will actually be published.