### PR TITLE
Fix incorrect TCP port examples

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -9,7 +9,7 @@
 //! # fn wrapper() -> Result<(), Error> {
 //! let mut port = Port::open_serial("/dev/ttyUSB0")?;
 //! // OR
-//! let mut port = Port::open_tcp("192.168.0.1:7770")?;
+//! let mut port = Port::open_tcp("192.168.0.1:55550")?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -156,7 +156,7 @@ impl Default for OpenSerialOptions {
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenTcpOptions::new()
 ///     .timeout(Some(Duration::from_millis(50)))
-///     .open("192.168.0.1:7770")?;
+///     .open("192.168.0.1:55550")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -308,9 +308,9 @@ impl Port<TcpStream> {
     /// ```rust
     /// # use zproto::ascii::{OpenTcpOptions, Port};
     /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut port = Port::open_tcp("198.168.0.1:7770")?;
+    /// let mut port = Port::open_tcp("198.168.0.1:55550")?;
     /// // Or equivalently
-    /// let mut port = OpenTcpOptions::new().open("198.168.0.1:7770")?;
+    /// let mut port = OpenTcpOptions::new().open("198.168.0.1:55550")?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -11,7 +11,7 @@
 //! # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 //! let mut port = Port::open_serial("/dev/ttyUSB0")?;
 //! // OR
-//! let mut port = Port::open_tcp("192.168.0.1:7770")?;
+//! let mut port = Port::open_tcp("192.168.0.1:55550")?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/binary/port.rs
+++ b/src/binary/port.rs
@@ -123,7 +123,7 @@ impl Default for OpenSerialOptions {
 /// # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut port = OpenTcpOptions::new()
 ///     .timeout(Some(Duration::from_millis(50)))
-///     .open("192.168.0.1:7770")?;
+///     .open("192.168.0.1:55550")?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
Zaber products use ports 55550 and 55551 for TCP connections.