### PR TITLE
Rename `rx` to `recv`

### DIFF
--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -10,24 +10,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Open the port and set up the chain
     let mut port = Port::open_serial(&port_path)?;
-    port.tx_rx_until_timeout((0, RENUMBER, 0))?;
+    port.tx_recv_until_timeout((0, RENUMBER, 0))?;
     port.set_message_ids(true)?;
 
     // Home device 1
-    port.tx_rx((device, HOME))?;
+    port.tx_recv((device, HOME))?;
     port.poll_until_idle(device)?;
 
     // Move towards the end of travel and monitor position as it goes.
-    port.tx_rx((device, MOVE_ABSOLUTE, 100_000))?;
+    port.tx_recv((device, MOVE_ABSOLUTE, 100_000))?;
     port.poll_until((device, RETURN_CURRENT_POSITION), |reply| {
         let pos = reply.data().unwrap();
         println!("{}", pos);
         pos == 100_000
     })?;
 
-    port.tx_rx((device, MOVE_ABSOLUTE, 25_000))?;
+    port.tx_recv((device, MOVE_ABSOLUTE, 25_000))?;
     port.poll_until_idle(1)?;
-    let reply = port.tx_rx((device, RETURN_CURRENT_POSITION))?;
+    let reply = port.tx_recv((device, RETURN_CURRENT_POSITION))?;
     println!("{}", reply.data()?);
     Ok(())
 }

--- a/test/binary/01-type-inference.rs
+++ b/test/binary/01-type-inference.rs
@@ -3,9 +3,9 @@ use zproto::binary::{DeviceMessage, Port, command::*};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut port = Port::open_serial("/dev/nonexistant")?;
     // Confirm the expected return types by explicitly marking them an INCORRECT type
-    let _: DeviceMessage<types::Reset> = port.tx_rx((0, HOME))?;
-    let _: DeviceMessage<types::Home> = port.tx_rx((0, untyped::HOME, 0i32))?;
-    let _: DeviceMessage<types::ReturnSetting> = port.tx_rx((0, RETURN_SETTING, RETURN_CURRENT_POSITION))?;
-    let _: DeviceMessage<types::ReturnSetting> = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
+    let _: DeviceMessage<types::Reset> = port.tx_recv((0, HOME))?;
+    let _: DeviceMessage<types::Home> = port.tx_recv((0, untyped::HOME, 0i32))?;
+    let _: DeviceMessage<types::ReturnSetting> = port.tx_recv((0, RETURN_SETTING, RETURN_CURRENT_POSITION))?;
+    let _: DeviceMessage<types::ReturnSetting> = port.tx_recv((0, RETURN_SETTING, SET_TARGET_SPEED))?;
     Ok(())
 }

--- a/test/binary/01-type-inference.stderr
+++ b/test/binary/01-type-inference.stderr
@@ -1,8 +1,8 @@
 error[E0308]: `?` operator has incompatible types
  --> test/binary/01-type-inference.rs:6:42
   |
-6 |     let _: DeviceMessage<types::Reset> = port.tx_rx((0, HOME))?;
-  |                                          ^^^^^^^^^^^^^^^^^^^^^^ expected struct `Reset`, found struct `Home`
+6 |     let _: DeviceMessage<types::Reset> = port.tx_recv((0, HOME))?;
+  |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Reset`, found struct `Home`
   |
   = note: `?` operator cannot convert from `DeviceMessage<Home>` to `DeviceMessage<Reset>`
   = note: expected struct `DeviceMessage<Reset>`
@@ -11,8 +11,8 @@ error[E0308]: `?` operator has incompatible types
 error[E0308]: `?` operator has incompatible types
  --> test/binary/01-type-inference.rs:7:41
   |
-7 |     let _: DeviceMessage<types::Home> = port.tx_rx((0, untyped::HOME, 0i32))?;
-  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Home`, found `u8`
+7 |     let _: DeviceMessage<types::Home> = port.tx_recv((0, untyped::HOME, 0i32))?;
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Home`, found `u8`
   |
   = note: `?` operator cannot convert from `DeviceMessage<u8>` to `DeviceMessage<Home>`
   = note: expected struct `DeviceMessage<Home>`
@@ -21,8 +21,8 @@ error[E0308]: `?` operator has incompatible types
 error[E0308]: `?` operator has incompatible types
  --> test/binary/01-type-inference.rs:8:50
   |
-8 |     let _: DeviceMessage<types::ReturnSetting> = port.tx_rx((0, RETURN_SETTING, RETURN_CURRENT_POSITION))?;
-  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `ReturnSetting`, found struct `ReturnCurrentPosition`
+8 |     let _: DeviceMessage<types::ReturnSetting> = port.tx_recv((0, RETURN_SETTING, RETURN_CURRENT_POSITION))?;
+  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `ReturnSetting`, found struct `ReturnCurrentPosition`
   |
   = note: `?` operator cannot convert from `DeviceMessage<ReturnCurrentPosition>` to `DeviceMessage<ReturnSetting>`
   = note: expected struct `DeviceMessage<ReturnSetting>`
@@ -31,8 +31,8 @@ error[E0308]: `?` operator has incompatible types
 error[E0308]: `?` operator has incompatible types
  --> test/binary/01-type-inference.rs:9:50
   |
-9 |     let _: DeviceMessage<types::ReturnSetting> = port.tx_rx((0, RETURN_SETTING, SET_TARGET_SPEED))?;
-  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `ReturnSetting`, found struct `SetTargetSpeed`
+9 |     let _: DeviceMessage<types::ReturnSetting> = port.tx_recv((0, RETURN_SETTING, SET_TARGET_SPEED))?;
+  |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `ReturnSetting`, found struct `SetTargetSpeed`
   |
   = note: `?` operator cannot convert from `DeviceMessage<SetTargetSpeed>` to `DeviceMessage<ReturnSetting>`
   = note: expected struct `DeviceMessage<ReturnSetting>`

--- a/test/binary/02-port-parameters.rs
+++ b/test/binary/02-port-parameters.rs
@@ -6,12 +6,12 @@ use zproto::{
 };
 
 fn _fail<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = port.tx_rx((0, RESET))?;  // Shouldn't work with tx_rx
-    let _ = port.tx_rx((0, HOME, 0i32))?;  // Shouldn't take parameters
-    let _ = port.tx_rx((0, MOVE_ABSOLUTE))?;  // Should take parameters
-    let _ = port.tx_rx((0, MOVE_ABSOLUTE, false))?;  // Wrong parameter type
+    let _ = port.tx_recv((0, RESET))?;  // Shouldn't work with tx_recv
+    let _ = port.tx_recv((0, HOME, 0i32))?;  // Shouldn't take parameters
+    let _ = port.tx_recv((0, MOVE_ABSOLUTE))?;  // Should take parameters
+    let _ = port.tx_recv((0, MOVE_ABSOLUTE, false))?;  // Wrong parameter type
 
-    let _ = port.tx_rx((0, untyped::HOME))?;  // u8 commands require an explicit data value
+    let _ = port.tx_recv((0, untyped::HOME))?;  // u8 commands require an explicit data value
 
     port.tx((0, ERROR))?;  // Reply-only commands cannot be transmitted
     port.tx((0, ERROR, 0i32))?;  // Reply-only commands cannot be transmitted
@@ -20,7 +20,7 @@ fn _fail<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error
 
 fn _ok<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
     port.tx((1, RESET))?;  // RESET can be transmitted
-    let _ = port.rx(MANUAL_MOVE_TRACKING)?; // Reply-only commands can be received
+    let _ = port.recv(MANUAL_MOVE_TRACKING)?; // Reply-only commands can be received
     Ok(())
 }
 

--- a/test/binary/02-port-parameters.stderr
+++ b/test/binary/02-port-parameters.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(u8, Reset): ElicitsResponse` is not satisfied
-   --> test/binary/02-port-parameters.rs:9:24
+   --> test/binary/02-port-parameters.rs:9:26
     |
-9   |     let _ = port.tx_rx((0, RESET))?;  // Shouldn't work with tx_rx
-    |                  ----- ^^^^^^^^^^ the trait `ElicitsResponse` is not implemented for `(u8, Reset)`
+9   |     let _ = port.tx_recv((0, RESET))?;  // Shouldn't work with tx_recv
+    |                  ------- ^^^^^^^^^^ the trait `ElicitsResponse` is not implemented for `(u8, Reset)`
     |                  |
     |                  required by a bound introduced by this call
     |
@@ -12,73 +12,73 @@ error[E0277]: the trait bound `(u8, Reset): ElicitsResponse` is not satisfied
               <(u8, ConvertToAscii) as ElicitsResponse>
               <(u8, ConvertToAscii, D) as ElicitsResponse>
             and 153 others
-note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_recv`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_recv`
 
 error[E0277]: the trait bound `Home: TakesData<i32>` is not satisfied
-   --> test/binary/02-port-parameters.rs:10:24
+   --> test/binary/02-port-parameters.rs:10:26
     |
-10  |     let _ = port.tx_rx((0, HOME, 0i32))?;  // Shouldn't take parameters
-    |                  ----- ^^^^^^^^^^^^^^^ the trait `TakesData<i32>` is not implemented for `Home`
+10  |     let _ = port.tx_recv((0, HOME, 0i32))?;  // Shouldn't take parameters
+    |                  ------- ^^^^^^^^^^^^^^^ the trait `TakesData<i32>` is not implemented for `Home`
     |                  |
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, Home, i32)`
-note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_recv`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_recv`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesNoData` is not satisfied
-   --> test/binary/02-port-parameters.rs:11:24
+   --> test/binary/02-port-parameters.rs:11:26
     |
-11  |     let _ = port.tx_rx((0, MOVE_ABSOLUTE))?;  // Should take parameters
-    |                  ----- ^^^^^^^^^^^^^^^^^^ the trait `TakesNoData` is not implemented for `MoveAbsolute`
+11  |     let _ = port.tx_recv((0, MOVE_ABSOLUTE))?;  // Should take parameters
+    |                  ------- ^^^^^^^^^^^^^^^^^^ the trait `TakesNoData` is not implemented for `MoveAbsolute`
     |                  |
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, MoveAbsolute)`
-note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_recv`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_recv`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesData<bool>` is not satisfied
-   --> test/binary/02-port-parameters.rs:12:24
+   --> test/binary/02-port-parameters.rs:12:26
     |
-12  |     let _ = port.tx_rx((0, MOVE_ABSOLUTE, false))?;  // Wrong parameter type
-    |                  ----- ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TakesData<bool>` is not implemented for `MoveAbsolute`
+12  |     let _ = port.tx_recv((0, MOVE_ABSOLUTE, false))?;  // Wrong parameter type
+    |                  ------- ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TakesData<bool>` is not implemented for `MoveAbsolute`
     |                  |
     |                  required by a bound introduced by this call
     |
     = help: the following implementations were found:
               <MoveAbsolute as TakesData<i32>>
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, MoveAbsolute, bool)`
-note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_recv`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_recv`
 
 error[E0277]: the trait bound `u8: TakesNoData` is not satisfied
-   --> test/binary/02-port-parameters.rs:14:24
+   --> test/binary/02-port-parameters.rs:14:26
     |
-14  |     let _ = port.tx_rx((0, untyped::HOME))?;  // u8 commands require an explicit data value
-    |                  ----- ^^^^^^^^^^^^^^^^^^ the trait `TakesNoData` is not implemented for `u8`
+14  |     let _ = port.tx_recv((0, untyped::HOME))?;  // u8 commands require an explicit data value
+    |                  ------- ^^^^^^^^^^^^^^^^^^ the trait `TakesNoData` is not implemented for `u8`
     |                  |
     |                  required by a bound introduced by this call
     |
     = note: required because of the requirements on the impl of `TxMessage` for `(u8, u8)`
-note: required by a bound in `zproto::binary::Port::<B>::tx_rx`
+note: required by a bound in `zproto::binary::Port::<B>::tx_recv`
    --> src/binary/port.rs
     |
     |         M: traits::TxMessage + traits::ElicitsResponse,
-    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_rx`
+    |            ^^^^^^^^^^^^^^^^^ required by this bound in `zproto::binary::Port::<B>::tx_recv`
 
 error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesNoData` is not satisfied
    --> test/binary/02-port-parameters.rs:16:13

--- a/test/binary/03-reply-data.rs
+++ b/test/binary/03-reply-data.rs
@@ -4,13 +4,13 @@ use zproto::{
 };
 
 fn _fail<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    let reply = port.tx_rx((0, MOVE_ABSOLUTE, 1000))?;
+    let reply = port.tx_recv((0, MOVE_ABSOLUTE, 1000))?;
     let value: bool = reply.data()?;  // Wrong data type, should be i32
     Ok(())
 }
 
 fn _ok<B: Backend>(port: &mut Port<B>) -> Result<(), Box<dyn std::error::Error>> {
-    let reply = port.tx_rx((0, MOVE_ABSOLUTE, 1000))?;
+    let reply = port.tx_recv((0, MOVE_ABSOLUTE, 1000))?;
     let value = reply.data()?;  // Shouldn't need any type hints
     let value: bool = reply.to_untyped().data()?; // Although incorrect, this is not a compile-time error.
     Ok(())


### PR DESCRIPTION
`tx` and `rx` are easily mistyped for one another. Replace `rx` with `recv`, which is also the name used in `std`.

Fixes #43 