### PR TITLE
Update logging format

### DIFF
--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -384,7 +384,7 @@ impl<B: Backend> Port<B> {
         );
         instance.write_into(&mut buffer)?;
         log::debug!(
-            "{} TX: {}",
+            "{} TX:   {}",
             self.backend
                 .get_ref()
                 .name()
@@ -686,7 +686,7 @@ impl<B: Backend> Port<B> {
         let result = result.map_err(From::from).and_then(|raw_packet| {
             // Log the packet
             log::debug!(
-                "{} RX: {}",
+                "{} RECV: {}",
                 &backend_name,
                 String::from_utf8_lossy(raw_packet).trim_end()
             );


### PR DESCRIPTION
Use RECV instead of RX to make it easier to distinguish from TX.
However, keep the packet bytes aligned between log entries for easier
reading.