### PR TITLE
Expose error::binary_code::name

### DIFF
--- a/src/error/binary.rs
+++ b/src/error/binary.rs
@@ -171,7 +171,7 @@ macro_rules! define_error_codes {
                 ///
                 /// If the error code is not recognized, `None` is returned.
                 /// The contents of the returned string may change.
-                pub(crate) const fn name(code: i32) -> Option<&'static str> {
+                pub const fn name(code: i32) -> Option<&'static str> {
                     match code {
                         $(
                             $num => Some(stringify!($($name_word)+)),


### PR DESCRIPTION
Previously users could get the name of binary error codes from the [`BinaryCommandFailureError::name()`](file:///home/stephen/Projects/zproto/target/doc/zproto/error/struct.BinaryCommandFailureError.html#) method. However, if users only have access to the a `binary::Message` it would still be good for them to be able to get the name of the error code. This change allows that.