### PR TITLE
Allow for custom default response checks

### DIFF
--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -256,7 +256,7 @@ impl Default for OpenTcpOptions {
 pub type OnPacketCallback<'a> = Box<dyn FnMut(&[u8], Direction) + 'a>;
 
 /// A wrapper around an [`OnPacketCallback`] that simply implements `Debug` so
-/// that the [`Port`] can implement `Debug`.
+/// that the [`Port`] can derive `Debug`.
 #[repr(transparent)]
 struct OnPacketCallbackDebugWrapper<'a>(OnPacketCallback<'a>);
 

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -329,6 +329,8 @@ pub enum Direction {
 /// port (`Port<Serial>`) or a TCP port (`Port<TcpStream>`). To customize the
 /// construction of these types, or to construct a port with a dynamic backend,
 /// use the [`OpenSerialOptions`] and [`OpenTcpOptions`] builder types.
+///
+/// See the [`ascii`](crate::ascii) module-level documentation for more details.
 #[derive(Debug)]
 pub struct Port<'a, B> {
     /// The underlying backend

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -1130,7 +1130,7 @@ impl<'a, B: Backend> Port<'a, B> {
     fn internal_responses_until_timeout_with_check<R, F, K>(
         &mut self,
         mut header_check: F,
-        check: Option<K>,
+        checker: Option<K>,
     ) -> Result<Vec<R>, AsciiError>
     where
         R: Response,
@@ -1142,7 +1142,8 @@ impl<'a, B: Backend> Port<'a, B> {
         self.pre_receive_response();
         let mut responses = Vec::new();
         loop {
-            match self.receive_response(|response| header_check(response), gen_new_checker(&check))
+            match self
+                .receive_response(|response| header_check(response), gen_new_checker(&checker))
             {
                 Ok(r) => responses.push(r),
                 Err(e) if e.is_timeout() => break,
@@ -1305,7 +1306,7 @@ impl<'a, B: Backend> Port<'a, B> {
     /// ```
     pub fn responses_until_timeout_with_check<R, K>(
         &mut self,
-        check: K,
+        checker: K,
     ) -> Result<Vec<R>, AsciiError>
     where
         R: Response,
@@ -1315,7 +1316,7 @@ impl<'a, B: Backend> Port<'a, B> {
     {
         self.internal_responses_until_timeout_with_check(
             |_| HeaderCheckAction::DoNotCheck,
-            Some(check),
+            Some(checker),
         )
     }
 

--- a/src/ascii/response.rs
+++ b/src/ascii/response.rs
@@ -31,7 +31,12 @@ pub trait Response:
 }
 
 /// A marker trait for specific ASCII response types, i.e., not [`AnyResponse`].
-pub trait SpecificResponse: Response {}
+// Anything implementing `Response` must also implement `TryFrom<AnyResponse>`
+// but this adds the extra restriction that the error is always `AnyResponse`.
+pub trait SpecificResponse:
+    Response + std::convert::TryFrom<AnyResponse, Error = AnyResponse>
+{
+}
 
 /// A trait for a response that contains a warning.
 pub trait ResponseWithWarning: Response {

--- a/src/ascii/response/alert.rs
+++ b/src/ascii/response/alert.rs
@@ -4,7 +4,6 @@ use crate::ascii::{
     response::{parse, AnyResponse, Header, Response, SpecificResponse, Status, Warning},
     Target,
 };
-use crate::error::*;
 
 /// The contents of an [`Alert`] message
 #[derive(Debug, Clone, PartialEq)]
@@ -17,7 +16,7 @@ pub(crate) struct AlertInner {
 
 /// A decoded Zaber ASCII Alert message.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Alert(Box<AlertInner>);
+pub struct Alert(pub(super) Box<AlertInner>);
 
 impl Alert {
     /// Try to convert a packet into an Alert message.
@@ -105,25 +104,6 @@ impl Response for Alert {
     }
     fn data(&self) -> &str {
         self.data()
-    }
-    #[doc(hidden)]
-    fn data_mut(&mut self) -> &mut String {
-        &mut self.0.data
-    }
-    // If this logic changes update the documentation for `ascii::check::default`
-    #[doc(hidden)]
-    fn default_check() -> fn(Self) -> Result<Self, AsciiCheckError<Self>> {
-        |alert| {
-            if alert.warning() == Warning::NONE {
-                Ok(alert)
-            } else {
-                Err(AsciiCheckWarningError::new(
-                    format!("expected {} warning flag", Warning::NONE),
-                    alert,
-                )
-                .into())
-            }
-        }
     }
 }
 

--- a/src/ascii/response/builder.rs
+++ b/src/ascii/response/builder.rs
@@ -76,6 +76,8 @@ impl ResponseBuilder {
     /// If the packet does not continue an existing message or does not start a
     /// new message, `AsciiUnexpectedPacketError` is returned.
     pub fn push(&mut self, packet: Packet) -> Result<(), AsciiUnexpectedPacketError> {
+        use super::private::DataMut as _;
+
         if packet.cont() {
             // This packet continues another, try to find a matching incomplete
             // message to append it to.

--- a/src/ascii/response/check.rs
+++ b/src/ascii/response/check.rs
@@ -25,20 +25,23 @@
 //! # }
 //! ```
 //!
-//! What this does should hopefully be somewhat self explanatory from the function names:
-//!   * [`all`] checks that all of the checks passed to it (notice that they are enclosed in a [`tuple`])
-//!   * [`flag_is`] checks that the reply flag on the [`Reply`] is the specified value
+//! What this does should hopefully be somewhat self explanatory from the
+//! function names:
+//!   * [`all`] checks that all of the checks passed to it (notice that they
+//!     are enclosed in a [`tuple`])
+//!   * [`flag_is`] checks that the reply flag on the [`Reply`] is the specified
+//!     value
 //!   * [`warning_is_none`] checks that the warning is `--`.
 //!
 //! This check is so common, however, that there is the [`default`] function
 //! which does the same thing.
 //!
-//! You can also check the status, warning, and data of responses using
-//! [`status_is`], one of the `warning_*` functions, and [`parsed_data_is`],
-//! respectively. If the validation logic for a response is more complex, the
-//! [`predicate`] function allows you to validate responses using a closure that
-//! simply returns a `bool`. Finally, to not check a response at all you can
-//! use [`unchecked`].
+//! You can also check the status, warning, reply flags, and data of responses
+//! using one of the `status_*`, `warning_*`, `flag_*`, or [`parsed_data_is`]
+//! functions, respectively. If the validation logic for a response is more
+//! complex, the [`predicate`] function allows you to validate responses using
+//! a closure that simply returns a `bool`. Finally, to not check a response at
+//! all you can use [`unchecked`].
 
 use crate::ascii::response::{
     AnyResponse, Flag, Reply, Response, ResponseWithStatus, ResponseWithWarning, SpecificResponse,

--- a/src/ascii/response/info.rs
+++ b/src/ascii/response/info.rs
@@ -4,7 +4,6 @@ use crate::ascii::{
     response::{parse, AnyResponse, Header, Response, SpecificResponse},
     Target,
 };
-use crate::error::*;
 
 /// The contents of an [`Info`] message.
 #[derive(Debug, Clone, PartialEq)]
@@ -16,7 +15,7 @@ pub(crate) struct InfoInner {
 
 /// A decoded Zaber ASCII Info message.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Info(Box<InfoInner>);
+pub struct Info(pub(super) Box<InfoInner>);
 
 impl Info {
     /// Try to convert a packet into an Info message.
@@ -95,15 +94,6 @@ impl Response for Info {
     }
     fn data(&self) -> &str {
         self.data()
-    }
-    #[doc(hidden)]
-    fn data_mut(&mut self) -> &mut String {
-        &mut self.0.data
-    }
-    // If this logic changes update the documentation for `ascii::check::default`
-    #[doc(hidden)]
-    fn default_check() -> fn(Self) -> Result<Self, AsciiCheckError<Self>> {
-        Ok
     }
 }
 

--- a/src/ascii/response/reply.rs
+++ b/src/ascii/response/reply.rs
@@ -4,7 +4,6 @@ use crate::ascii::{
     response::{parse, AnyResponse, Header, Response, SpecificResponse, Status, Warning},
     Target,
 };
-use crate::error::*;
 
 /// A reply flag.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -41,7 +40,7 @@ pub(crate) struct ReplyInner {
 
 /// A decoded ASCII Reply message.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Reply(Box<ReplyInner>);
+pub struct Reply(pub(super) Box<ReplyInner>);
 
 impl Reply {
     /// Try to convert a packet into an Reply message.
@@ -140,27 +139,6 @@ impl Response for Reply {
     }
     fn data(&self) -> &str {
         self.data()
-    }
-    #[doc(hidden)]
-    fn data_mut(&mut self) -> &mut String {
-        &mut self.0.data
-    }
-    // If this logic changes update the documentation for `ascii::check::default`
-    #[doc(hidden)]
-    fn default_check() -> fn(Self) -> Result<Self, AsciiCheckError<Self>> {
-        |reply| {
-            if reply.flag() != Flag::Ok {
-                Err(AsciiCheckFlagError::new(Flag::Ok, reply).into())
-            } else if reply.warning() != Warning::NONE {
-                Err(AsciiCheckWarningError::new(
-                    format!("expected {} warning flag", Warning::NONE),
-                    reply,
-                )
-                .into())
-            } else {
-                Ok(reply)
-            }
-        }
     }
 }
 

--- a/src/error/ascii.rs
+++ b/src/error/ascii.rs
@@ -112,7 +112,6 @@ macro_rules! impl_from_specific_to_any_response {
         impl<R> From<$name<R>> for $name<AnyResponse>
         where
             R: SpecificResponse,
-            AnyResponse: From<R>,
         {
             fn from(other: $name<R>) -> Self {
                 $name(Box::new((other.0 .0, other.0 .1.into())))
@@ -453,7 +452,6 @@ impl TryFrom<AsciiError> for AsciiCheckError<AnyResponse> {
 impl<R> From<AsciiCheckError<R>> for AsciiCheckError<AnyResponse>
 where
     R: SpecificResponse,
-    AnyResponse: From<R>,
 {
     fn from(other: AsciiCheckError<R>) -> Self {
         match other {


### PR DESCRIPTION
Previously the contents of all responses were checked with the `check::default()`, which is quite strict, and not appropriate in most cases. This change still uses `check::default()` by default but allows users to customize it.