### PR TITLE
Refactor the `ascii::Target` API

### DIFF
--- a/src/ascii/command.rs
+++ b/src/ascii/command.rs
@@ -81,7 +81,7 @@ impl Command for str {
         self
     }
     fn target(&self) -> Target {
-        Target::all()
+        Target::for_all()
     }
     fn data(&self) -> Cow<[u8]> {
         self.as_bytes().into()
@@ -95,7 +95,7 @@ impl Command for [u8] {
         self
     }
     fn target(&self) -> Target {
-        Target::all()
+        Target::for_all()
     }
     fn data(&self) -> Cow<[u8]> {
         self.into()
@@ -109,7 +109,7 @@ impl<const N: usize> Command for [u8; N] {
         self
     }
     fn target(&self) -> Target {
-        Target::all()
+        Target::for_all()
     }
     fn data(&self) -> Cow<[u8]> {
         self.as_slice().into()
@@ -123,7 +123,7 @@ impl Command for String {
         self.as_bytes()
     }
     fn target(&self) -> Target {
-        Target::all()
+        Target::for_all()
     }
     fn data(&self) -> Cow<[u8]> {
         self.as_bytes().into()
@@ -137,7 +137,7 @@ impl Command for Vec<u8> {
         self.as_slice()
     }
     fn target(&self) -> Target {
-        Target::all()
+        Target::for_all()
     }
     fn data(&self) -> Cow<[u8]> {
         self.as_slice().into()
@@ -172,7 +172,7 @@ where
         self
     }
     fn target(&self) -> Target {
-        Target::device(self.0).axis(self.1)
+        Target::for_device(self.0).with_axis(self.1)
     }
     fn data(&self) -> Cow<[u8]> {
         self.2.as_ref().into()
@@ -277,23 +277,18 @@ impl<'a> CommandInstance<'a> {
                 write!(
                     writer,
                     "{} {} {}",
-                    self.target.get_device(),
-                    self.target.get_axis(),
+                    self.target.device(),
+                    self.target.axis(),
                     id
                 )?;
                 true
             }
             None => {
-                if self.target.get_axis() != 0 {
-                    write!(
-                        writer,
-                        "{} {}",
-                        self.target.get_device(),
-                        self.target.get_axis()
-                    )?;
+                if self.target.axis() != 0 {
+                    write!(writer, "{} {}", self.target.device(), self.target.axis())?;
                     true
-                } else if self.target.get_device() != 0 {
-                    write!(writer, "{}", self.target.get_device())?;
+                } else if self.target.device() != 0 {
+                    write!(writer, "{}", self.target.device())?;
                     true
                 } else {
                     false
@@ -345,10 +340,10 @@ mod test {
 
     #[test]
     fn test_target() {
-        assert_eq!(Target::default(), Target::all());
-        assert_eq!(Target::device(1), Target(1, 0));
-        assert_eq!(Target::device(1).axis(1), Target(1, 1));
-        assert_eq!(Target::new(5, 9).all_axes(), Target(5, 0));
+        assert_eq!(Target::default(), Target::for_all());
+        assert_eq!(Target::for_device(1), Target(1, 0));
+        assert_eq!(Target::for_device(1).with_axis(1), Target(1, 1));
+        assert_eq!(Target::new(5, 9).with_all_axes(), Target(5, 0));
     }
 
     #[test]

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -2625,7 +2625,7 @@ mod test {
             let mut port = Port::open_mock();
             port.set_default_response_check(|any_response| match &any_response {
                 AnyResponse::Reply(reply) if reply.status() == Status::Busy => Ok(any_response),
-                AnyResponse::Alert(alert) if alert.target().get_device() == 1 => Ok(any_response),
+                AnyResponse::Alert(alert) if alert.target().device() == 1 => Ok(any_response),
                 AnyResponse::Info(info) if info.data().contains("is-ok") => Ok(any_response),
                 _ => Err(AsciiCheckCustomError::new("Oops", any_response).into()),
             });

--- a/src/ascii/response/alert.rs
+++ b/src/ascii/response/alert.rs
@@ -79,8 +79,8 @@ impl std::fmt::Display for Alert {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", char::from(parse::ALERT_MARKER))?;
         Header {
-            address: self.target().get_device(),
-            axis: self.target().get_axis(),
+            address: self.target().device(),
+            axis: self.target().axis(),
             id: None,
         }
         .fmt(f)?;

--- a/src/ascii/response/info.rs
+++ b/src/ascii/response/info.rs
@@ -73,8 +73,8 @@ impl std::fmt::Display for Info {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", char::from(parse::INFO_MARKER))?;
         Header {
-            address: self.target().get_device(),
-            axis: self.target().get_axis(),
+            address: self.target().device(),
+            axis: self.target().axis(),
             id: self.id(),
         }
         .fmt(f)?;

--- a/src/ascii/response/reply.rs
+++ b/src/ascii/response/reply.rs
@@ -112,8 +112,8 @@ impl std::fmt::Display for Reply {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", char::from(parse::REPLY_MARKER))?;
         Header {
-            address: self.target().get_device(),
-            axis: self.target().get_axis(),
+            address: self.target().device(),
+            axis: self.target().axis(),
             id: self.id(),
         }
         .fmt(f)?;


### PR DESCRIPTION
The previous API was a mix of constructors and getters. However, the constructors looked like getters, the getters didn't follow the Rust API guidelines (they started with `get_`). This change makes the constructors read more clearly as constructors and makes the getters follow the API guidelines. It also expands the documentation to avoid confusion.

Closes #86 