### PR TITLE
Add `is_io()` helper method to errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,11 +71,30 @@ macro_rules! impl_error_display {
 #[cfg(any(feature = "ascii", feature = "binary"))]
 macro_rules! impl_is_timeout {
     ($name:ident) => {
+        paste::paste! {
+            impl $name {
+                /// A convenience function for determining if the error is due to the
+                /// port timing out.
+                ///
+                /// Note that a timeout error is a kind of IO error, so [`is_io`][1] will
+                /// also return true for timeout errors.
+                ///
+                #[doc = "[1]: " $name "::is_io"]
+                pub fn is_timeout(&self) -> bool {
+                    matches!(self, $name::Io(e) if e.kind() == std::io::ErrorKind::TimedOut)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(any(feature = "ascii", feature = "binary"))]
+macro_rules! impl_is_io {
+    ($name:ident) => {
         impl $name {
-            /// A convenience function for determining if the error is due to the
-            /// port timing out.
-            pub fn is_timeout(&self) -> bool {
-                matches!(self, $name::Io(e) if e.kind() == std::io::ErrorKind::TimedOut)
+            /// A convenience function for determining if the error is an IO error.
+            pub fn is_io(&self) -> bool {
+                matches!(self, $name::Io(_))
             }
         }
     };

--- a/src/error/all.rs
+++ b/src/error/all.rs
@@ -69,6 +69,7 @@ error_enum! {
     }
 }
 impl_is_timeout! { Error }
+impl_is_io! { Error }
 impl_from_serialport_error! { Error }
 impl_from_ascii_check_error! {
     Error {

--- a/src/error/ascii.rs
+++ b/src/error/ascii.rs
@@ -495,6 +495,7 @@ error_enum! {
     }
 }
 impl_is_timeout! { AsciiError }
+impl_is_io! { AsciiError }
 impl_from_serialport_error! { AsciiError }
 impl_from_ascii_check_error! {
     AsciiError {

--- a/src/error/binary.rs
+++ b/src/error/binary.rs
@@ -124,6 +124,7 @@ error_enum! {
     }
 }
 impl_is_timeout! { BinaryError }
+impl_is_io! { BinaryError }
 impl_from_serialport_error! { BinaryError }
 
 macro_rules! define_error_codes {


### PR DESCRIPTION
Unlike most other errors, IO errors may be unrecoverable (perhaps the device on the other end disconnected abruptly) so it is helpful to know whether that kind of error has occurred.