### PR TITLE
Split long commands using line continuations

### DIFF
--- a/src/ascii/checksum.rs
+++ b/src/ascii/checksum.rs
@@ -30,15 +30,6 @@ impl Lrc {
         sum
     }
 
-    /// Hash the input
-    pub fn hash(input: &[u8]) -> u32 {
-        let mut hasher = Lrc::default();
-        for byte in input {
-            hasher.update(*byte);
-        }
-        hasher.finish()
-    }
-
     /// Verif if the hash matches the input.
     pub fn verify(input: &[u8], hash: u32) -> bool {
         let sum: u32 = input.iter().fold(0u32, |sum, b| *b as u32 + sum);

--- a/src/ascii/checksum.rs
+++ b/src/ascii/checksum.rs
@@ -1,5 +1,7 @@
 //! Types for producing and verifying ASCII packet checksums
 
+use std::io;
+
 /// A Longitudinal Redundancy Check hasher.
 #[derive(Debug, Default)]
 pub(crate) struct Lrc {
@@ -13,12 +15,18 @@ impl Lrc {
         self.sum = (self.sum + byte as u32) & 0xFF;
     }
 
+    /// Clear the hasher's state. This returns the hasher to the state after
+    /// initially calling `Lrc::default()`.
+    pub fn reset(&mut self) {
+        self.sum = 0;
+    }
+
     /// Finish calculating the Lrc hash.
     ///
     /// The hasher's state is reset.
     pub fn finish(&mut self) -> u32 {
         let sum = ((self.sum ^ 0xFF) + 1) & 0xFF;
-        self.sum = 0;
+        self.reset();
         sum
     }
 
@@ -38,13 +46,97 @@ impl Lrc {
     }
 }
 
+/// A type that implement [`io::Write`] and calculates the LRC of the data
+/// written to it.
+#[derive(Debug)]
+pub(crate) struct LrcWriter<W> {
+    hasher: Lrc,
+    writer: W,
+}
+
+impl<W> LrcWriter<W> {
+    /// Create a new `LrcWriter` wrapping `writer`.
+    pub fn new(writer: W) -> LrcWriter<W> {
+        LrcWriter {
+            hasher: Lrc::default(),
+            writer,
+        }
+    }
+
+    /// Reset the hash state.
+    pub fn reset_hash(&mut self) {
+        self.hasher.reset();
+    }
+
+    /// Calculate the hash for the data received so far and reset the hash state.
+    pub fn finish_hash(&mut self) -> u32 {
+        self.hasher.finish()
+    }
+
+    /// Consume this writer and return the inner one.
+    #[cfg(test)]
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+impl<W> io::Write for LrcWriter<W>
+where
+    W: io::Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for byte in buf {
+            self.hasher.update(*byte)
+        }
+        self.writer.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::Write as _;
 
     #[test]
     fn test_lrc() {
         assert!(Lrc::verify(b"01 tools echo", 143));
         assert!(!Lrc::verify(b"01 tools echo", 142));
+    }
+
+    /// Writing to an LrcWriter should both write the data and correctly update the hash.
+    #[test]
+    fn test_lrc_writer() {
+        let buf = Vec::with_capacity(80);
+        let writer = std::io::Cursor::new(buf);
+
+        let mut lrc_writer = LrcWriter::new(writer);
+        write!(&mut lrc_writer, "hello world").unwrap();
+        let hash = lrc_writer.finish_hash();
+        assert!(Lrc::verify(b"hello world", hash));
+        assert_eq!(
+            lrc_writer.into_inner().into_inner().as_slice(),
+            b"hello world"
+        );
+    }
+
+    /// Writing to an LrcWriter should both write the data and correctly update the hash.
+    #[test]
+    fn test_lrc_writer_reset_hash() {
+        let buf = Vec::with_capacity(80);
+        let writer = std::io::Cursor::new(buf);
+
+        let mut lrc_writer = LrcWriter::new(writer);
+        write!(&mut lrc_writer, "hello ").unwrap();
+        lrc_writer.reset_hash();
+        write!(&mut lrc_writer, "world").unwrap();
+        let hash = lrc_writer.finish_hash();
+        assert!(Lrc::verify(b"world", hash));
+        assert_eq!(
+            lrc_writer.into_inner().into_inner().as_slice(),
+            b"hello world"
+        );
     }
 }

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -457,6 +457,9 @@ impl<'a, B: Backend> Port<'a, B> {
     ///
     /// On success, the generated message ID (if any) is returned.
     ///
+    /// If necessary, the command will be split into multiple packets so that no
+    /// packet is longer than [`max_packet_size`](Self::max_packet_size).
+    ///
     /// ## Example
     ///
     /// ```rust
@@ -498,6 +501,9 @@ impl<'a, B: Backend> Port<'a, B> {
     }
 
     /// Transmit a command, receive a reply, and check it with the [`strict`](check::strict) check.
+    ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
     ///
     /// If the reply is split across multiple packets, the continuation messages will automatically be read.
     ///
@@ -541,6 +547,9 @@ impl<'a, B: Backend> Port<'a, B> {
 
     /// Transmit a command and receive a reply.
     ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
+    ///
     /// If any response is spread across multiple packets, continuation packets will be read.
     /// `header_check` should be a function that produces data for validating the response's header.
     ///
@@ -572,6 +581,9 @@ impl<'a, B: Backend> Port<'a, B> {
     /// Transmit a command and then receive a reply and all subsequent info messages.
     ///
     /// The reply and info messages are checked with the [`strict`](check::strict) check.
+    ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
     ///
     /// If the reply or info messages are split across multiple packets, the continuation messages will automatically be read.
     ///
@@ -639,6 +651,9 @@ impl<'a, B: Backend> Port<'a, B> {
 
     /// Transmit a command and then receive a reply and all subsequent info messages.
     ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
+    ///
     /// If any response is spread across multiple packets, continuation packets will be read.
     /// `header_check` should be a function that produces data for validating the response's header.
     ///
@@ -688,6 +703,9 @@ impl<'a, B: Backend> Port<'a, B> {
 
     /// Transmit a command, receive n replies, and check each reply with the [`strict`](check::strict) check.
     ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
+    ///
     /// If any of the replies are split across multiple packets, the continuation messages will automatically be read.
     ///
     /// ## Example
@@ -735,6 +753,9 @@ impl<'a, B: Backend> Port<'a, B> {
 
     /// Transmit a command and then receive n replies.
     ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
+    ///
     /// If any response is spread across multiple packets, continuation packets will be read.
     /// `header_check` should be a function that produces data for validating the response's header.
     ///
@@ -763,6 +784,9 @@ impl<'a, B: Backend> Port<'a, B> {
     }
 
     /// Transmit a command, receive replies until the port times out, and check each reply with the [`strict`](check::strict) check.
+    ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
     ///
     /// If any of the replies are split across multiple packets, the continuation messages will automatically be read.
     ///
@@ -811,6 +835,9 @@ impl<'a, B: Backend> Port<'a, B> {
     }
 
     /// Transmit a command and then receive replies until the port times out.
+    ///
+    /// If necessary, the command will be split into multiple packets so that no packet is longer than
+    /// [`max_packet_size`](Self::max_packet_size).
     ///
     /// If any response is spread across multiple packets, continuation packets will be read.
     /// `header_check` should be a function that produces data for validating the response's header.
@@ -1324,6 +1351,9 @@ impl<'a, B: Backend> Port<'a, B> {
     /// the replies are checked with the [`strict`](check::strict)
     /// check.
     ///
+    /// If necessary, the command will be split into multiple packets so that no
+    /// packet is longer than [`max_packet_size`](Self::max_packet_size).
+    ///
     /// If any of the replies are split across multiple packets, the
     /// continuation messages will automatically be read.
     ///
@@ -1379,6 +1409,9 @@ impl<'a, B: Backend> Port<'a, B> {
 
     /// Send the specified command repeatedly until the predicate returns true
     /// for a reply.
+    ///
+    /// If necessary, the command will be split into multiple packets so that no
+    /// packet is longer than [`max_packet_size`](Self::max_packet_size).
     ///
     /// If any response is spread across multiple packets, continuation packets will be read.
     /// `header_check` should be a function that produces data for validating the response's header.

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -9,8 +9,8 @@ use crate::{
         checksum::Lrc,
         id,
         parse::{Packet, PacketKind},
-        Alert, AnyResponse, Command, CommandWriter, Info, Reply, Response, ResponseBuilder, Status,
-        Target,
+        Alert, AnyResponse, Command, CommandWriter, Info, MaxPacketSize, Reply, Response,
+        ResponseBuilder, Status, Target,
     },
     error::*,
     timeout_guard::TimeoutGuard,
@@ -442,6 +442,7 @@ impl<'a, B: Backend> Port<'a, B> {
             &mut self.ids,
             self.generate_id,
             self.generate_checksum,
+            MaxPacketSize::default(),
         );
         let mut more_packets = true;
         while more_packets {

--- a/src/error/all.rs
+++ b/src/error/all.rs
@@ -25,6 +25,7 @@ error_enum! {
         AsciiCheckWarning(AsciiCheckWarningError<AnyResponse>),
         AsciiCheckData(AsciiCheckDataError<AnyResponse>),
         AsciiCheckCustom(AsciiCheckCustomError<AnyResponse>),
+        AsciiCommandSplit(AsciiCommandSplitError),
         BinaryCommandFailure(BinaryCommandFailureError),
         BinaryUnexpectedTarget(BinaryUnexpectedTargetError),
         BinaryUnexpectedId(BinaryUnexpectedIdError),
@@ -51,6 +52,7 @@ error_enum! {
         CheckWarning => AsciiCheckWarning,
         CheckData => AsciiCheckData,
         CheckCustom => AsciiCheckCustom,
+        CommandSplit => AsciiCommandSplit,
     }
 
     impl From<BinaryUnexpectedError> {


### PR DESCRIPTION
Previously command that were too long would be ignored by devices. This change uses the ASCII protocol line continuation feature to split long commands into multiple packets so that the devices can receive it.

Fixes #105 