### PR TITLE
Disallow reserved characters in command data

### DIFF
--- a/src/error/all.rs
+++ b/src/error/all.rs
@@ -26,6 +26,7 @@ error_enum! {
         AsciiCheckData(AsciiCheckDataError<AnyResponse>),
         AsciiCheckCustom(AsciiCheckCustomError<AnyResponse>),
         AsciiCommandSplit(AsciiCommandSplitError),
+        AsciiReservedCharacter(AsciiReservedCharacterError),
         BinaryCommandFailure(BinaryCommandFailureError),
         BinaryUnexpectedTarget(BinaryUnexpectedTargetError),
         BinaryUnexpectedId(BinaryUnexpectedIdError),
@@ -53,6 +54,7 @@ error_enum! {
         CheckData => AsciiCheckData,
         CheckCustom => AsciiCheckCustom,
         CommandSplit => AsciiCommandSplit,
+        ReservedCharacter => AsciiReservedCharacter,
     }
 
     impl From<BinaryUnexpectedError> {


### PR DESCRIPTION
The use of reserved characters can a command's data field may cause a BADCOMMAND rejected but may also cause the command to be ignored or incorrectly interpreted by the device. To avoid these problems check for these characters in the command before writing out the command.

Fixes #108 