### PR TITLE
Only run cargo check on ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -Dwarnings
     steps:


### PR DESCRIPTION
Type checking should not depend on the host OS, so remove redundant work.