### PR TITLE
Update version to 0.4.0-pre

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zproto"
-version = "0.3.5-pre"
+version = "0.4.0-pre"
 authors = ["Stephen Hunt <stphnhnt.git@gmail.com>"]
 edition = "2021"
 description = "A library from communicating with Zaber products in Rust."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml:
 
 ```toml
 [dependencies]
-zproto = "0.3.4"
+zproto = "0.4.0-pre"
 ```
 
 ## Getting started
@@ -65,7 +65,7 @@ By default, both the ASCII and Binary protocols are enabled via the `ascii` and
 
 ```toml
 [dependencies]
-zproto = { version = "0.3.4", default-features = false, features = ["ascii"] }
+zproto = { version = "0.4.0-pre", default-features = false, features = ["ascii"] }
 ```
 
 This will only include portions of the library related to the ASCII protocol


### PR DESCRIPTION
The README previously had 0.3.4 while Cargo.toml had 0.3.5-pre. This was confusing/inconsistent and may have prompted people to think the main source branch was the same as 0.3.4, which it is not. This change makes the versions consistent and avoids any confusion.