### PR TITLE
Sendable port

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -153,6 +153,24 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Sending a Port between threads
+//!
+//! By default a [`Port`] does not implement `Send`, so cannot be sent to another
+//! thread. If you're application requires this, use the [`Port::try_into_send`]
+//! method to convert it to one that can be. Doing so places [`Send`] bounds on
+//! any [packet](Port::set_packet_handler) or [unexpected alert](Port::set_unexpected_alert_handler)
+//! handlers.
+//!
+//! ```
+//! # use zproto::ascii::Port;
+//! # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
+//! let sendable_port = Port::open_serial("...")?
+//!     .try_into_send()
+//!     .unwrap();
+//! # Ok(())
+//! # }
+//! ```
 
 pub(crate) mod checksum;
 mod command;

--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -89,7 +89,6 @@ pub enum Direction {
 /// use the [`OpenSerialOptions`] and [`OpenTcpOptions`] builder types.
 ///
 /// See the [`ascii`](crate::ascii) module-level documentation for more details.
-#[derive(Debug)]
 pub struct Port<'a, B> {
     /// The underlying backend
     backend: B,
@@ -120,6 +119,14 @@ pub struct Port<'a, B> {
     packet_hook: Option<PacketCallbackDebugWrapper<'a>>,
     /// Optional hook to call when an unexpected Alert is received.
     unexpected_alert_hook: Option<UnexpectedAlertDebugWrapper<'a>>,
+}
+
+impl<'a, B: Backend> std::fmt::Debug for Port<'a, B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Port")
+            .field("name", &self.backend.name())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> Port<'a, Serial> {

--- a/src/ascii/port/handlers.rs
+++ b/src/ascii/port/handlers.rs
@@ -85,6 +85,8 @@ impl<'a> Handlers for LocalHandlers<'a> {
     }
 }
 
+impl<'a> private::Sealed for LocalHandlers<'a> {}
+
 /// Implementation detail.
 ///
 /// Collection of event handlers that can be sent to other threads (i.e. they implement `Send`).
@@ -111,8 +113,10 @@ impl<'a> Handlers for SendHandlers<'a> {
     }
 }
 
+impl<'a> private::Sealed for SendHandlers<'a> {}
+
 /// Any type that defines event handlers for a [`Port`].
-pub trait Handlers: Default {
+pub trait Handlers: Default + private::Sealed {
     /// The type of function called when a packet is sent/received.
     type PacketHandler;
     /// The type of function called when an unexpected alert message is received.
@@ -122,4 +126,8 @@ pub trait Handlers: Default {
     fn packet(&mut self) -> &mut Option<Self::PacketHandler>;
     /// Get the unexpected alert handler, if configured.
     fn unexpected_alert(&mut self) -> &mut Option<Self::UnexpectedAlertHandler>;
+}
+
+mod private {
+    pub trait Sealed {}
 }

--- a/src/ascii/port/handlers.rs
+++ b/src/ascii/port/handlers.rs
@@ -1,0 +1,29 @@
+//! Handlers for events on a port.
+#[cfg(doc)]
+use super::Port;
+use super::{Alert, Direction};
+
+/// A callback that is called after a packet is either transmitted or received.
+///
+/// See [`Port::set_packet_handler`] for more details.
+pub type PacketHandler<'a> = Box<dyn FnMut(&[u8], Direction) + 'a>;
+
+/// A callback that is called when an unexpected Alert is received.
+///
+/// See [`Port::set_unexpected_alert_handler`] for more details.
+pub type UnexpectedAlertHandler<'a> = Box<dyn FnMut(Alert) -> Result<(), Alert> + 'a>;
+
+/// Implementation detail.
+///
+/// Collection of event handlers that can only be used in the local thread.
+#[derive(Default)]
+pub struct LocalHandlers<'a> {
+    pub(super) packet: Option<PacketHandler<'a>>,
+    pub(super) unexpected_alert: Option<UnexpectedAlertHandler<'a>>,
+}
+
+impl std::fmt::Debug for LocalHandlers<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalHandlers").finish_non_exhaustive()
+    }
+}

--- a/src/ascii/port/test.rs
+++ b/src/ascii/port/test.rs
@@ -32,7 +32,7 @@ macro_rules! check_cases {
         $(
             $port.backend.append_data($response_bytes);
         )+
-        let m: fn(&mut Port<_>) -> Result<_, _> = $method; // Give the compiler the necessary type hints
+        let m: fn(&mut Port<_, _>) -> Result<_, _> = $method; // Give the compiler the necessary type hints
         match (m)(&mut $port) {
             Err(e) => panic!("unexpected error when reading {} via {}:\n\tactual error: {}\n\t{:?}\n",
                 stringify!($($response_bytes),+),
@@ -51,7 +51,7 @@ macro_rules! check_cases {
         $(
             $port.backend.append_data($response_bytes);
         )+
-        let m: fn(&mut Port<_>) -> Result<_, _> = $method; // Give the compiler the necessary type hints
+        let m: fn(&mut Port<_, _>) -> Result<_, _> = $method; // Give the compiler the necessary type hints
         match (m)(&mut $port) {
             Err(e) => {
                 if let Err(e) = $err_type::try_from(e) {

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -206,12 +206,14 @@
 //!
 
 pub mod command;
+mod handlers;
 mod port;
 pub mod traits;
 
 use std::convert::Infallible;
 
 use crate::error;
+pub use handlers::*;
 pub use port::*;
 
 /// A Binary Protocol message.

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -105,6 +105,23 @@
 //! # }
 //! ```
 //!
+//! ## Sending a Port between threads
+//!
+//! By default a [`Port`] does not implement `Send`, so cannot be sent to another
+//! thread. If you're application requires this, use the [`Port::try_into_send`]
+//! method to convert it to one that can be. Doing so places [`Send`] bounds on
+//! any [packet](Port::set_packet_handler) handlers.
+//!
+//! ```
+//! # use zproto::ascii::Port;
+//! # fn wrapper() -> Result<(), Box<dyn std::error::Error>> {
+//! let sendable_port = Port::open_serial("...")?
+//!     .try_into_send()
+//!     .unwrap();
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## Type Safety
 //!
 //! The library uses Rust's type system and the strongly-typed commands in the

--- a/src/binary/handlers.rs
+++ b/src/binary/handlers.rs
@@ -55,6 +55,7 @@ impl<'a> Handlers for LocalHandlers<'a> {
         &mut self.packet
     }
 }
+impl<'a> private::Sealed for LocalHandlers<'a> {}
 
 /// Implementation detail.
 ///
@@ -76,12 +77,17 @@ impl<'a> Handlers for SendHandlers<'a> {
         &mut self.packet
     }
 }
+impl<'a> private::Sealed for SendHandlers<'a> {}
 
 /// Any type that defines callbacks for a [`Port`].
-pub trait Handlers: Default {
+pub trait Handlers: Default + private::Sealed {
     /// The type of function called when a packet is sent/received.
     type PacketHandler;
 
     /// Get the packet callback, if configured.
     fn packet(&mut self) -> &mut Option<Self::PacketHandler>;
+}
+
+mod private {
+    pub trait Sealed {}
 }

--- a/src/binary/handlers.rs
+++ b/src/binary/handlers.rs
@@ -1,0 +1,27 @@
+//! Event handlers for ports.
+#[cfg(doc)]
+use super::Port;
+use super::{Direction, Message};
+
+/// An event handler that is called after a packet is either transmitted or received.
+///
+/// See [`Port::set_packet_handler`] for more details.
+pub type PacketHandler<'a> = Box<dyn FnMut(&[u8], Message, Direction) + 'a>;
+
+/// Deprecated. Use [`PacketHandler`] instead.
+#[deprecated = "use the PacketHandler alias instead"]
+pub type PacketCallback<'a> = PacketHandler<'a>;
+
+/// Implementation detail.
+///
+/// A collection of event handlers that can only be used in the local thread.
+#[derive(Default)]
+pub struct LocalHandlers<'a> {
+    pub(super) packet: Option<PacketHandler<'a>>,
+}
+
+impl std::fmt::Debug for LocalHandlers<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalHandlers").finish_non_exhaustive()
+    }
+}

--- a/src/binary/handlers.rs
+++ b/src/binary/handlers.rs
@@ -8,6 +8,15 @@ use super::{Direction, Message};
 /// See [`Port::set_packet_handler`] for more details.
 pub type PacketHandler<'a> = Box<dyn FnMut(&[u8], Message, Direction) + 'a>;
 
+impl<'a, F> crate::convert::From<F> for PacketHandler<'a>
+where
+    F: FnMut(&[u8], Message, Direction) + 'a,
+{
+    fn from(value: F) -> Self {
+        Box::new(value)
+    }
+}
+
 /// Deprecated. Use [`PacketHandler`] instead.
 #[deprecated = "use the PacketHandler alias instead"]
 pub type PacketCallback<'a> = PacketHandler<'a>;
@@ -24,4 +33,20 @@ impl std::fmt::Debug for LocalHandlers<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LocalHandlers").finish_non_exhaustive()
     }
+}
+
+impl<'a> Handlers for LocalHandlers<'a> {
+    type PacketHandler = PacketHandler<'a>;
+    fn packet(&mut self) -> &mut Option<Self::PacketHandler> {
+        &mut self.packet
+    }
+}
+
+/// Any type that defines callbacks for a [`Port`].
+pub trait Handlers: Default {
+    /// The type of function called when a packet is sent/received.
+    type PacketHandler;
+
+    /// Get the packet callback, if configured.
+    fn packet(&mut self) -> &mut Option<Self::PacketHandler>;
 }

--- a/src/binary/port.rs
+++ b/src/binary/port.rs
@@ -254,7 +254,6 @@ pub enum Direction {
 ///
 /// See the [`binary`](crate::binary) module documentation details on how to use
 /// a `Port`.
-#[derive(Debug)]
 pub struct Port<'a, B> {
     /// The backend to transmit/receive commands with
     backend: B,
@@ -275,6 +274,14 @@ pub struct Port<'a, B> {
     poison: Option<io::Error>,
     /// Optional hook to call after a packet is sent/received.
     packet_hook: Option<PacketCallbackDebugWrapper<'a>>,
+}
+
+impl<'a, B: Backend> std::fmt::Debug for Port<'a, B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Port")
+            .field("name", &self.backend.name())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> Port<'a, Serial> {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,9 @@
+//! Custom conversion traits.
+
+/// Custom conversion trait.
+///
+/// Mirrors [`std::convert::From`] but is used when `std` trait cannot be.
+pub trait From<T>: Sized {
+    /// Create an instance of the type from another type `T`.
+    fn from(value: T) -> Self;
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -376,3 +376,20 @@ impl_error_display! {
     self =>
     "the specified device is either disconnected or already in use by another process: {}", self.0
 }
+
+/// The port could not be converted into one that implements `Send`.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct TryIntoSendError(());
+
+impl TryIntoSendError {
+    /// Create a new `TryIntoSendError`.
+    pub(crate) fn new() -> Self {
+        TryIntoSendError(())
+    }
+}
+
+impl_error_display! {
+    TryIntoSendError,
+    self =>
+    "cannot convert the port into one that implements `Send`"
+}

--- a/src/error/all.rs
+++ b/src/error/all.rs
@@ -14,6 +14,7 @@ error_enum! {
     pub enum Error {
         SerialDeviceInUseOrDisconnected(SerialDeviceInUseOrDisconnectedError),
         Io(std::io::Error),
+        TryIntoSend(TryIntoSendError),
         AsciiPacketMissingStart(AsciiPacketMissingStartError),
         AsciiPacketMissingEnd(AsciiPacketMissingEndError),
         AsciiPacketMalformed(AsciiPacketMalformedError),
@@ -42,6 +43,7 @@ error_enum! {
     impl From<AsciiError> {
         SerialDeviceInUseOrDisconnected => SerialDeviceInUseOrDisconnected,
         Io => Io,
+        TryIntoSend => TryIntoSend,
         PacketMissingStart => AsciiPacketMissingStart,
         PacketMissingEnd => AsciiPacketMissingEnd,
         PacketMalformed => AsciiPacketMalformed,
@@ -66,6 +68,7 @@ error_enum! {
     impl From<BinaryError> {
         SerialDeviceInUseOrDisconnected => SerialDeviceInUseOrDisconnected,
         Io => Io,
+        TryIntoSend => TryIntoSend,
         CommandFailure => BinaryCommandFailure,
         UnexpectedTarget => BinaryUnexpectedTarget,
         UnexpectedId => BinaryUnexpectedId,

--- a/src/error/ascii.rs
+++ b/src/error/ascii.rs
@@ -1,6 +1,6 @@
 //! Error types related to Zaber's ASCII protocol.
 
-use super::SerialDeviceInUseOrDisconnectedError;
+use super::{SerialDeviceInUseOrDisconnectedError, TryIntoSendError};
 use crate::ascii::{
     parse::Packet, Alert, AnyResponse, Command, Flag, Info, Reply, Response, SpecificResponse,
     Status, Target,
@@ -626,6 +626,7 @@ error_enum! {
     pub enum AsciiError {
         SerialDeviceInUseOrDisconnected(SerialDeviceInUseOrDisconnectedError),
         Io(std::io::Error),
+        TryIntoSend(TryIntoSendError),
         PacketMissingStart(AsciiPacketMissingStartError),
         PacketMissingEnd(AsciiPacketMissingEndError),
         PacketMalformed(AsciiPacketMalformedError),

--- a/src/error/binary.rs
+++ b/src/error/binary.rs
@@ -1,6 +1,6 @@
 //! Error types for the Zaber's Binary protocol.
 
-use super::SerialDeviceInUseOrDisconnectedError;
+use super::{SerialDeviceInUseOrDisconnectedError, TryIntoSendError};
 use crate::binary::Message;
 
 macro_rules! impl_binary_error {
@@ -111,6 +111,7 @@ error_enum! {
     pub enum BinaryError {
         SerialDeviceInUseOrDisconnected(SerialDeviceInUseOrDisconnectedError),
         Io(std::io::Error),
+        TryIntoSend(TryIntoSendError),
         CommandFailure(BinaryCommandFailureError),
         UnexpectedTarget(BinaryUnexpectedTargetError),
         UnexpectedId(BinaryUnexpectedIdError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod backend;
 #[cfg(feature = "binary")]
 #[cfg_attr(all(doc, feature = "doc_cfg"), doc(cfg(feature = "binary")))]
 pub mod binary;
+pub mod convert;
 pub mod error;
 pub mod timeout_guard;
 

--- a/src/timeout_guard.rs
+++ b/src/timeout_guard.rs
@@ -19,7 +19,7 @@ mod private {
     #[cfg(feature = "ascii")]
     impl<'a, B, H> Sealed for crate::ascii::Port<'a, B, H> {}
     #[cfg(feature = "binary")]
-    impl<'a, B> Sealed for crate::binary::Port<'a, B> {}
+    impl<'a, B, H> Sealed for crate::binary::Port<'a, B, H> {}
 }
 
 /// An [RAII guard](https://rust-unofficial.github.io/patterns/patterns/behavioural/RAII.html)

--- a/src/timeout_guard.rs
+++ b/src/timeout_guard.rs
@@ -17,7 +17,7 @@ mod private {
     /// Marks a trait a sealed.
     pub trait Sealed {}
     #[cfg(feature = "ascii")]
-    impl<'a, B> Sealed for crate::ascii::Port<'a, B> {}
+    impl<'a, B, H> Sealed for crate::ascii::Port<'a, B, H> {}
     #[cfg(feature = "binary")]
     impl<'a, B> Sealed for crate::binary::Port<'a, B> {}
 }

--- a/test/binary/02-port-parameters.stderr
+++ b/test/binary/02-port-parameters.stderr
@@ -16,14 +16,14 @@ error[E0277]: the trait bound `(u8, Reset): ElicitsResponse` is not satisfied
             (u8, StoreCurrentPosition)
             (u8, StoreCurrentPosition, D)
           and $N others
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx_recv`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx_recv`
  --> src/binary/port.rs
   |
   |     pub fn tx_recv<M>(&mut self, message: M) -> Result<Message<M::Response>, BinaryError>
   |            ------- required by a bound in this associated function
   |     where
   |         M: traits::TxMessage + traits::ElicitsResponse,
-  |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx_recv`
+  |                                ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx_recv`
 
 error[E0277]: the trait bound `Home: TakesData<i32>` is not satisfied
   --> test/binary/02-port-parameters.rs:10:30
@@ -44,14 +44,14 @@ error[E0277]: the trait bound `Home: TakesData<i32>` is not satisfied
              <MoveAtConstantSpeed as TakesData<i32>>
            and $N others
    = note: required for `(u8, Home, i32)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx_recv`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx_recv`
   --> src/binary/port.rs
    |
    |     pub fn tx_recv<M>(&mut self, message: M) -> Result<Message<M::Response>, BinaryError>
    |            ------- required by a bound in this associated function
    |     where
    |         M: traits::TxMessage + traits::ElicitsResponse,
-   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx_recv`
+   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx_recv`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesNoData` is not satisfied
   --> test/binary/02-port-parameters.rs:11:30
@@ -72,14 +72,14 @@ error[E0277]: the trait bound `MoveAbsolute: TakesNoData` is not satisfied
              ReturnFirmwareBuild
            and $N others
    = note: required for `(u8, MoveAbsolute)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx_recv`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx_recv`
   --> src/binary/port.rs
    |
    |     pub fn tx_recv<M>(&mut self, message: M) -> Result<Message<M::Response>, BinaryError>
    |            ------- required by a bound in this associated function
    |     where
    |         M: traits::TxMessage + traits::ElicitsResponse,
-   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx_recv`
+   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx_recv`
 
 error[E0277]: the trait bound `MoveAbsolute: TakesData<bool>` is not satisfied
   --> test/binary/02-port-parameters.rs:12:30
@@ -92,14 +92,14 @@ error[E0277]: the trait bound `MoveAbsolute: TakesData<bool>` is not satisfied
    = help: the trait `TakesData<i32>` is implemented for `MoveAbsolute`
    = help: for that trait implementation, expected `i32`, found `bool`
    = note: required for `(u8, MoveAbsolute, bool)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx_recv`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx_recv`
   --> src/binary/port.rs
    |
    |     pub fn tx_recv<M>(&mut self, message: M) -> Result<Message<M::Response>, BinaryError>
    |            ------- required by a bound in this associated function
    |     where
    |         M: traits::TxMessage + traits::ElicitsResponse,
-   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx_recv`
+   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx_recv`
 
 error[E0277]: the trait bound `u8: TakesNoData` is not satisfied
   --> test/binary/02-port-parameters.rs:14:30
@@ -120,14 +120,14 @@ error[E0277]: the trait bound `u8: TakesNoData` is not satisfied
              ReturnFirmwareBuild
            and $N others
    = note: required for `(u8, u8)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx_recv`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx_recv`
   --> src/binary/port.rs
    |
    |     pub fn tx_recv<M>(&mut self, message: M) -> Result<Message<M::Response>, BinaryError>
    |            ------- required by a bound in this associated function
    |     where
    |         M: traits::TxMessage + traits::ElicitsResponse,
-   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx_recv`
+   |            ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx_recv`
 
 error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesNoData` is not satisfied
   --> test/binary/02-port-parameters.rs:16:17
@@ -148,11 +148,11 @@ error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesNoDat
              ReturnFirmwareBuild
            and $N others
    = note: required for `(u8, zproto::binary::command::types::Error)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx`
   --> src/binary/port.rs
    |
    |     pub fn tx<M: traits::TxMessage>(&mut self, message: M) -> Result<Option<u8>, BinaryError> {
-   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx`
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx`
 
 error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesData<i32>` is not satisfied
   --> test/binary/02-port-parameters.rs:17:17
@@ -173,8 +173,8 @@ error[E0277]: the trait bound `zproto::binary::command::types::Error: TakesData<
              <MoveAtConstantSpeed as TakesData<i32>>
            and $N others
    = note: required for `(u8, zproto::binary::command::types::Error, i32)` to implement `TxMessage`
-note: required by a bound in `zproto::binary::Port::<'a, B>::tx`
+note: required by a bound in `zproto::binary::Port::<'a, B, H>::tx`
   --> src/binary/port.rs
    |
    |     pub fn tx<M: traits::TxMessage>(&mut self, message: M) -> Result<Option<u8>, BinaryError> {
-   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B>::tx`
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Port::<'a, B, H>::tx`


### PR DESCRIPTION
This should fix #156 in a non-breaking way.

It makes the `ascii::Port` and `binary::Port` generic over their callback types. The type parameter's default implements the current behaviour, so existing code will work as before. To allow sending a `Port` between threads, each `Port` now has a `try_into_send` method which will replace the callback type with one requiring `Send`. 

```rust
let sendable_port = Port::open_serial("...")?.try_into_send().unwrap();

// send it to whatever thread you want.
```

This change includes documentation for the new method.