### PR TITLE
Remove unused and unpublished error types

### DIFF
--- a/src/error/all.rs
+++ b/src/error/all.rs
@@ -32,8 +32,6 @@ error_enum! {
 		BinaryUnexpectedTarget(BinaryUnexpectedTargetError),
 		BinaryUnexpectedId(BinaryUnexpectedIdError),
 		BinaryUnexpectedCommand(BinaryUnexpectedCommandError),
-		LockPoisoned(LockPoisonedError),
-		LockUnavailable(LockUnavailableError),
 		Conversion(ConversionError),
 		DuplicateAddress(DuplicateAddressError),
 	}
@@ -61,8 +59,6 @@ error_enum! {
 		CheckCustom => AsciiCheckCustom,
 		CommandSplit => AsciiCommandSplit,
 		ReservedCharacter => AsciiReservedCharacter,
-		LockPoisoned => LockPoisoned,
-		LockUnavailable => LockUnavailable,
 		Conversion => Conversion,
 		DuplicateAddress => DuplicateAddress,
 	}
@@ -81,11 +77,6 @@ error_enum! {
 		UnexpectedTarget => BinaryUnexpectedTarget,
 		UnexpectedId => BinaryUnexpectedId,
 		UnexpectedCommand => BinaryUnexpectedCommand,
-	}
-
-	impl From<LockError> {
-		Poisoned => LockPoisoned,
-		Unavailable => LockUnavailable,
 	}
 }
 impl_is_timeout! { Error }
@@ -112,25 +103,6 @@ impl TryFrom<Error> for AsciiCheckError<AnyResponse> {
 			Error::AsciiCheckCustom(e) => Ok(AsciiCheckError::Custom(e)),
 			e => Err(e),
 		}
-	}
-}
-
-/// The locking mechanism protecting the data is "poisoned" and can no longer be relied upon.
-#[derive(Debug)]
-pub struct LockPoisonedError;
-impl_error_display! { LockPoisonedError, self => "data locking mechanism is poisoned and can no longer be relied upon" }
-
-/// The data is already locked and is therefore unavailable.
-#[derive(Debug)]
-pub struct LockUnavailableError;
-impl_error_display! { LockUnavailableError, self => "data is already locked and is therefore unavailable" }
-
-error_enum! {
-	/// Errors returned when trying to lock a resource.
-	#[derive(Debug)]
-	pub enum LockError {
-		Poisoned(LockPoisonedError),
-		Unavailable(LockUnavailableError),
 	}
 }
 
@@ -175,7 +147,6 @@ mod test {
 	assert_impl_all!(Error: From<AsciiCheckError<Alert>>);
 	assert_impl_all!(Error: From<AsciiError>);
 	assert_impl_all!(Error: From<BinaryError>);
-	assert_impl_all!(Error: From<LockError>);
 
 	assert_impl_all!(AsciiError: TryFrom<Error>);
 
@@ -183,6 +154,4 @@ mod test {
 	assert_impl_all!(AsciiCheckError<AnyResponse>: TryFrom<Error>);
 
 	assert_impl_all!(BinaryError: TryFrom<Error>);
-
-	assert_impl_all!(LockError: TryFrom<Error>);
 }

--- a/src/error/ascii.rs
+++ b/src/error/ascii.rs
@@ -6,9 +6,7 @@ use crate::ascii::{
 	packet::Packet,
 	response::{Alert, AnyResponse, Flag, Info, Reply, Response, SpecificResponse, Status},
 };
-use crate::error::{
-	ConversionError, DuplicateAddressError, LockError, LockPoisonedError, LockUnavailableError,
-};
+use crate::error::{ConversionError, DuplicateAddressError};
 
 /// Implement the `new()` and `as_bytes()` methods errors storing bytes.
 macro_rules! impl_for_type_containing_bytes {
@@ -644,8 +642,6 @@ error_enum! {
 		CheckCustom(AsciiCheckCustomError<AnyResponse>),
 		CommandSplit(AsciiCommandSplitError),
 		ReservedCharacter(AsciiReservedCharacterError),
-		LockPoisoned(LockPoisonedError),
-		LockUnavailable(LockUnavailableError),
 		Conversion(ConversionError),
 		DuplicateAddress(DuplicateAddressError),
 	}
@@ -654,11 +650,6 @@ error_enum! {
 		PacketMissingStart => PacketMissingStart,
 		PacketMissingEnd => PacketMissingEnd,
 		PacketMalformed => PacketMalformed,
-	}
-
-	impl From<LockError> {
-		Poisoned => LockPoisoned,
-		Unavailable => LockUnavailable,
 	}
 }
 impl_is_timeout! { AsciiError }
@@ -696,11 +687,9 @@ mod test {
 	assert_impl_all!(AsciiError: From<AsciiCheckError<Reply>>);
 	assert_impl_all!(AsciiError: From<AsciiCheckError<Info>>);
 	assert_impl_all!(AsciiError: From<AsciiCheckError<Alert>>);
-	assert_impl_all!(AsciiError: From<LockError>);
 
 	assert_impl_all!(AsciiProtocolError: TryFrom<AsciiError>);
 	assert_impl_all!(AsciiCheckError<AnyResponse>: TryFrom<AsciiError>);
-	assert_impl_all!(LockError: TryFrom<AsciiError>);
 
 	// Check that error types and responses they wrap implement AsRef and From,
 	// respectively.


### PR DESCRIPTION
This error types were accidentally left in `main` after rolling back an API that was never released.