### PR TITLE
Update simple_logger dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ paste = "1.0.12"
 serialport = "4.2.1"
 
 [dev-dependencies]
-simple_logger = "4.2.0"
+simple_logger = "5.0.0"
 static_assertions = "1.1.0"
 trybuild = "1.0.80"
 


### PR DESCRIPTION
Rust 1.80 broke type inferencing for older versions of the time crate, which the previously used version of the time simple_logger crate depended upon. See https://github.com/rust-lang/rust/issues/128242 for more details.

This change bumps the dependency, allowing tests and examples to compile properly.