### PR TITLE
Add callback function for mocks

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -154,7 +154,7 @@ impl Mock {
 			flush_error: None,
 			set_read_timeout_error: None,
 			ignored_read_timeout: Some(Duration::ZERO),
-			reply_callback: |buf, _| buf.extend_from_slice(b""),
+			reply_callback: |_, _| (),
 		}
 	}
 	/// Push data to the read buffer.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -211,7 +211,7 @@ impl Mock {
 	///     buf.extend_from_slice(match msg {
 	///         b"/1 io get ai 1\n" => b"@01 0 OK BUSY -- 5.5\r\n",
 	///         b"/get pos\n" => b"@01 0 OK BUSY -- 20\r\n@02 0 OK BUSY -- 10.1\r\n",
-	///         _ => panic!("unexpected messsage"),
+	///         _ => panic!("unexpected message"),
 	///     })
 	/// );
 	/// let reply = port.command_reply((1,"io get ai 1"))?.flag_ok()?;


### PR DESCRIPTION
I was playing around with the mocks and I thought it would be nice to have a callback function to generate responses based on received commands.

With this pull request, it is possible to do the following:

 ```rust
backend.set_reply_callback(|x| match std::str::from_utf8(x) {
    Ok("/1 io get ai 1\n") => b"@01 0 OK BUSY -- 5.5\r\n".to_vec(),
    Ok("/1 lockstep 1 move abs 5\n") => b"@01 0 OK BUSY -- 0\r\n".to_vec(),
    Ok("/get pos\n") => b"@01 0 OK BUSY -- 20\r\n@02 0 OK BUSY -- 10.1\r\n".to_vec(),
    Ok(i) => panic!("Invalid input {}", i),
    Err(e) => panic!("{}", e.to_string()),
});
```

Let me know what you think about this addition.