### PR TITLE
Expose the Backend Trait publicly

### DIFF
--- a/src/ascii/port.rs
+++ b/src/ascii/port.rs
@@ -219,7 +219,7 @@ where
 	H::UnexpectedAlertHandler: FnMut(Alert) -> Result<(), Alert> + 'a,
 {
 	/// Create a `Port` from a [`Backend`] type.
-	fn from_backend(
+	pub fn from_backend(
 		backend: B,
 		generate_id: bool,
 		generate_checksum: bool,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -17,7 +17,7 @@ use sp::TTYPort as ExternSerial;
 pub(crate) const UNKNOWN_BACKEND_NAME: &str = "<unknown backend>";
 
 /// Types that allow reading and writing bytes with a connected device.
-pub trait Backend: io::Read + io::Write + private::Sealed {
+pub trait Backend: io::Read + io::Write {
 	/// Set the read timeout.
 	///
 	/// If timeout is `None`, reads will block indefinitely.
@@ -292,6 +292,7 @@ impl io::Write for Mock {
 }
 
 mod private {
+    #[allow(dead_code)]
 	pub trait Sealed {}
 
 	impl Sealed for super::Serial {}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -290,15 +290,3 @@ impl io::Write for Mock {
 		}
 	}
 }
-
-mod private {
-    #[allow(dead_code)]
-	pub trait Sealed {}
-
-	impl Sealed for super::Serial {}
-	impl Sealed for std::net::TcpStream {}
-	#[cfg(any(test, feature = "mock"))]
-	impl Sealed for super::Mock {}
-	impl<C: super::Backend + ?Sized> Sealed for Box<C> {}
-	impl<C: super::Backend + ?Sized> Sealed for &mut C {}
-}


### PR DESCRIPTION
For testing purposes, I want to use `Port` with a custom simulator as backend. This would be as simple as implementing the `Backend` trait for my simulator struct. Unfortunately, `Backend` is currently not accessible outside the crate.

This pull request removes the `Sealed` trait and consequently makes `Backend` publicly accessible. Users can now implement their own backend and instantiate ports with `Port::from_backend()`.

Let me know what you think! 