### PR TITLE
Remove unnecessary use of paste crate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,18 +71,16 @@ macro_rules! impl_error_display {
 #[cfg(any(feature = "ascii", feature = "binary"))]
 macro_rules! impl_is_timeout {
 	($name:ident) => {
-		paste::paste! {
-			impl $name {
-				/// A convenience function for determining if the error is due to the
-				/// port timing out.
-				///
-				/// Note that a timeout error is a kind of IO error, so [`is_io`][1] will
-				/// also return true for timeout errors.
-				///
-				#[doc = "[1]: " $name "::is_io"]
-				pub fn is_timeout(&self) -> bool {
-					matches!(self, $name::Io(e) if e.kind() == std::io::ErrorKind::TimedOut)
-				}
+		impl $name {
+			/// A convenience function for determining if the error is due to the
+			/// port timing out.
+			///
+			/// Note that a timeout error is a kind of IO error, so [`is_io`][1] will
+			/// also return true for timeout errors.
+			///
+			#[doc = concat!("[1]: ", stringify!($name), "::is_io")]
+			pub fn is_timeout(&self) -> bool {
+				matches!(self, $name::Io(e) if e.kind() == std::io::ErrorKind::TimedOut)
 			}
 		}
 	};


### PR DESCRIPTION
The desired behaviour does not require the paste in this case, so don't over complicate it.